### PR TITLE
Handle OAuth Flow and Add Functionality to Invalidate an HttpSession

### DIFF
--- a/src/main/java/servlets/BillingConfig.java
+++ b/src/main/java/servlets/BillingConfig.java
@@ -66,7 +66,7 @@ public class BillingConfig extends HttpServlet {
      * TODO: @cade, eventually you will want to pass this access token into the 
      * updateSheets() method in the SheetsConverter class.
      */
-    HttpSession session = request.getSession();
+    HttpSession session = request.getSession(false);
     String accessToken = session.getAttribute("accessToken").toString();
 
     SheetsConverter sheet = new SheetsConverter(); 

--- a/src/main/java/servlets/BillingConfig.java
+++ b/src/main/java/servlets/BillingConfig.java
@@ -66,6 +66,7 @@ public class BillingConfig extends HttpServlet {
      * TODO: @cade, eventually you will want to pass this access token into the 
      * updateSheets() method in the SheetsConverter class.
      */
+    // Only retrieves the session if one exists.
     HttpSession session = request.getSession(false);
     String accessToken = session.getAttribute("accessToken").toString();
 

--- a/src/main/java/servlets/InvalidateSessionServlet.java
+++ b/src/main/java/servlets/InvalidateSessionServlet.java
@@ -20,7 +20,7 @@ import com.google.appengine.api.users.UserService;
 import com.google.appengine.api.users.UserServiceFactory;
 import util.UserAuthUtil;
 
-@WebServlet("/Invalidate")
+@WebServlet("/InvalidateSession")
 public class InvalidateSessionServlet extends HttpServlet {
 
   // Invalidate the HttpSession that holds the access token.

--- a/src/main/java/servlets/InvalidateSessionServlet.java
+++ b/src/main/java/servlets/InvalidateSessionServlet.java
@@ -1,0 +1,32 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package servlets;
+
+import java.io.IOException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.*;
+import com.google.appengine.api.users.UserService;
+import com.google.appengine.api.users.UserServiceFactory;
+import util.UserAuthUtil;
+
+@WebServlet("/Invalidate")
+public class InvalidateSessionServlet extends HttpServlet {
+
+  // Invalidate the HttpSession that holds the access token.
+  @Override
+  public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
+    HttpSession session = request.getSession(true);
+    session.invalidate();
+  }
+}

--- a/src/main/java/servlets/InvalidateSessionServlet.java
+++ b/src/main/java/servlets/InvalidateSessionServlet.java
@@ -26,7 +26,7 @@ public class InvalidateSessionServlet extends HttpServlet {
   // Invalidate the HttpSession that holds the access token.
   @Override
   public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
-    HttpSession session = request.getSession(true);
+    HttpSession session = request.getSession(false);
     session.invalidate();
   }
 }

--- a/src/main/java/servlets/InvalidateSessionServlet.java
+++ b/src/main/java/servlets/InvalidateSessionServlet.java
@@ -26,6 +26,7 @@ public class InvalidateSessionServlet extends HttpServlet {
   // Invalidate the HttpSession that holds the access token.
   @Override
   public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
+    // Only retrieves the session if one exists.
     HttpSession session = request.getSession(false);
     session.invalidate();
   }

--- a/src/main/java/servlets/LoginServlet.java
+++ b/src/main/java/servlets/LoginServlet.java
@@ -13,71 +13,27 @@
 // limitations under the License.
 package servlets;
 
-import java.net.URI;
 import java.io.IOException;
-import java.util.logging.Logger;
 import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import data.ResponseBuilder;
 import java.io.PrintWriter;
-import java.math.BigInteger;
-import java.security.SecureRandom;
-import java.util.logging.Logger;
-import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.*;
 import com.google.appengine.api.users.UserService;
 import com.google.appengine.api.users.UserServiceFactory;
 import util.UserAuthUtil;
-import util.OAuthConstants;
 
 @WebServlet("/Login")
 public class LoginServlet extends HttpServlet {
-  private static final Logger LOGGER = Logger.getLogger(LoginServlet.class.getName());
   private static final String CONTENT_TYPE_TEXT_HTML = "text/html;";
   private static final String REDIRECT_LINK = "/Login";
 
-  // Returns a URL to either login and get OAuth tokens or to logout.
+  // Returns a URL to either login or logout.
   @Override
   public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
-    // Create a state token to prevent request forgery.
-    String state = new BigInteger(130, new SecureRandom()).toString(32);
-    HttpSession session = request.getSession(true);
-    session.setAttribute(OAuthConstants.SHEETS_SESSION_KEY, state);
-
     response.setContentType(CONTENT_TYPE_TEXT_HTML);
     response.getWriter().println(ResponseBuilder.toJson(UserAuthUtil.isUserLoggedIn(), REDIRECT_LINK));
-    if (!UserAuthUtil.isUserLoggedIn()) {
-      response.sendRedirect(getOAuthRedirectURL());
-    }
-  }
-
-  /** 
-   * Build the OAuth consent page redirect URL. 
-   * 
-   * ex URL: https://accounts.google.com/o/oauth2/v2/auth?client_id=150737768611
-   * -svndjtlklolq53g4ass4r3sqal2i31p5.apps.googleusercontent.com&scope=https://
-   * www.googleapis.com/auth/spreadsheets&response_type=code&redirect_uri=https:
-   * //8080-479d0277-462e-4e1c-8481-71f13e508859.us-central1.cloudshell.dev/api/
-   * oauth/callback/sheets&state=907bnrlkufr2cf43ukdq6s97j4
-   */
-  private String getOAuthRedirectURL(String state) {
-    return String.format("%s?%s&%s&%s&%s&%s", OAuthConstants.OAUTH_LOGIN_URI, 
-      OAuthConstants.CLIENT_ID, OAuthConstants.SCOPE, OAuthConstants.RESPONSE_TYPE, 
-      getRedirectUri(), OAuthConstants.STATE + state); 
-  }
-
-  // Build a valid redirect URI to the OAuthCallbackServlet.
-  private String getRedirectUri() {
-    try {
-      URI domainUri = URI.create(System.getenv().get(
-        OAuthConstants.ENVIRONMENT_VARIABLE));
-      return OAuthConstants.REDIRECT_URI + domainUri.resolve(
-        OAuthConstants.OAUTH_CALLBACK_SERVLET).toString();
-    } catch (NullPointerException e) {
-      LOGGER.severe("The DOMAIN environment variable is not set.");
-      throw e;
-    }
   }
 }

--- a/src/main/java/servlets/OAuthCallbackServlet.java
+++ b/src/main/java/servlets/OAuthCallbackServlet.java
@@ -45,6 +45,8 @@ public class OAuthCallbackServlet extends HttpServlet {
   private final String ACCESS_TOKEN_PARAM = "access_token";
   private final String HEADER_TYPE = "Content-Type";
   private final String HEADER_FORM = "application/x-www-form-urlencoded";
+  private final String READFILE_PAGE = "/readfile.html";
+
 
   @Override
   public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
@@ -52,12 +54,15 @@ public class OAuthCallbackServlet extends HttpServlet {
     String authCode = request.getParameter(CODE_PARAM);
     String state = request.getParameter(STATE_PARAM);
 
+    System.out.println("GOT HERE");
+
     // Print any error the OAuth provider gave us.
     if (error != null && !error.isEmpty()) {
       response.getWriter().print(error);
       response.setStatus(401);
       return;
     }
+
 
     // Check that the OAuth provider gave us the authorization code.
     if (authCode == null || authCode.isEmpty()) {
@@ -85,12 +90,11 @@ public class OAuthCallbackServlet extends HttpServlet {
     // Parse to find access token.
     JsonElement accessToken = parseAccessToken(tokenResponseBody); 
 
-    response.setContentType("text/html");
-    response.getWriter().printf("<h1>the access token for the Sheets API is %s</h1>", accessToken);
-
     // Store access token in a session.
     HttpSession session = request.getSession();
     session.setAttribute("accessToken", accessToken.toString());
+
+    response.sendRedirect(READFILE_PAGE);
   }
 
   // Build a valid redirect URI to the OAuthCallbackServlet.

--- a/src/main/java/servlets/OAuthCallbackServlet.java
+++ b/src/main/java/servlets/OAuthCallbackServlet.java
@@ -54,15 +54,12 @@ public class OAuthCallbackServlet extends HttpServlet {
     String authCode = request.getParameter(CODE_PARAM);
     String state = request.getParameter(STATE_PARAM);
 
-    System.out.println("GOT HERE");
-
     // Print any error the OAuth provider gave us.
     if (error != null && !error.isEmpty()) {
       response.getWriter().print(error);
       response.setStatus(401);
       return;
     }
-
 
     // Check that the OAuth provider gave us the authorization code.
     if (authCode == null || authCode.isEmpty()) {

--- a/src/main/java/servlets/OAuthConsentServlet.java
+++ b/src/main/java/servlets/OAuthConsentServlet.java
@@ -1,0 +1,78 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package servlets;
+
+import java.net.URI;
+import java.io.IOException;
+import java.util.logging.Logger;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import data.ResponseBuilder;
+import java.io.PrintWriter;
+import java.math.BigInteger;
+import java.security.SecureRandom;
+import java.util.logging.Logger;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.*;
+import com.google.appengine.api.users.UserService;
+import com.google.appengine.api.users.UserServiceFactory;
+import util.UserAuthUtil;
+import util.OAuthConstants;
+
+@WebServlet("/OAuth")
+public class OAuthConsentServlet extends HttpServlet {
+  private static final Logger LOGGER = Logger.getLogger(LoginServlet.class.getName());
+
+  // Handle the OAuth consent flow.
+  @Override
+  public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
+    // Create a state token to prevent request forgery.
+    String state = new BigInteger(130, new SecureRandom()).toString(32);
+    HttpSession session = request.getSession(true);
+    session.setAttribute(OAuthConstants.SHEETS_SESSION_KEY, state);
+
+    // Redirect user to OAuthConsentPage.
+    response.sendRedirect(getOAuthRedirectURL(state));
+  }
+
+  /** 
+   * Build the OAuth consent page redirect URL. 
+   * 
+   * ex URL: https://accounts.google.com/o/oauth2/v2/auth?client_id=150737768611
+   * -svndjtlklolq53g4ass4r3sqal2i31p5.apps.googleusercontent.com&scope=https://
+   * www.googleapis.com/auth/spreadsheets&response_type=code&redirect_uri=https:
+   * //8080-479d0277-462e-4e1c-8481-71f13e508859.us-central1.cloudshell.dev/api/
+   * oauth/callback/sheets&state=907bnrlkufr2cf43ukdq6s97j4
+   */
+  private String getOAuthRedirectURL(String state) {
+    return String.format("%s?%s&%s&%s&%s&%s", OAuthConstants.OAUTH_LOGIN_URI, 
+      OAuthConstants.CLIENT_ID, OAuthConstants.SCOPE, OAuthConstants.RESPONSE_TYPE, 
+      getRedirectUri(), OAuthConstants.STATE + state); 
+  }
+
+  // Build a valid redirect URI to the OAuthCallbackServlet.
+  private String getRedirectUri() {
+    try {
+      URI domainUri = URI.create(System.getenv().get(
+        OAuthConstants.ENVIRONMENT_VARIABLE));
+      return OAuthConstants.REDIRECT_URI + domainUri.resolve(
+        OAuthConstants.OAUTH_CALLBACK_SERVLET).toString();
+    } catch (NullPointerException e) {
+      LOGGER.severe("The DOMAIN environment variable is not set.");
+      throw e;
+    }
+  }
+}

--- a/src/main/java/servlets/OAuthConsentServlet.java
+++ b/src/main/java/servlets/OAuthConsentServlet.java
@@ -41,6 +41,8 @@ public class OAuthConsentServlet extends HttpServlet {
   public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
     // Create a state token to prevent request forgery.
     String state = new BigInteger(130, new SecureRandom()).toString(32);
+
+    // Get the current session or create a new one.
     HttpSession session = request.getSession(true);
     session.setAttribute(OAuthConstants.SHEETS_SESSION_KEY, state);
 


### PR DESCRIPTION
Separate the Login and OAuth functionality into separate servlets. The OAuthConsentServlet guides users through the process to get access tokens to use the Sheets API. This servlet will be called after the UI sees that the user is logged in. The InvalidateSessionServlet ends a session so that access tokens aren't preserved when the app is exited.

TODO: Structure UI in a way that properly uses the Login and OAuth servlets.