### PR TITLE
Fix Account Sheet Bug and Add Headers to Sheets

### DIFF
--- a/src/main/java/data/Account.java
+++ b/src/main/java/data/Account.java
@@ -153,7 +153,6 @@ public class Account {
     this.aggregationMode = aggregationMode;
   }
 
-
   public static List<String> getAccountSheetHeader() {
     String[] accountData = { 
       FormIdNames.ACCOUNT_ID, 

--- a/src/main/java/data/Account.java
+++ b/src/main/java/data/Account.java
@@ -154,10 +154,10 @@ public class Account {
   }
 
   /** Builds one row filled with an Account's data for the Sheet. */
-  public List<String> getAccountSheetsRow() {
+  public List<String> getAccountSheetsRow(String vendorID) {
     String[] accountData = { 
       getAccountID(), 
-      getVendorID(), 
+      vendorID, 
       getEntity(), 
       getCurrency(), 
       getDirection(),

--- a/src/main/java/data/Account.java
+++ b/src/main/java/data/Account.java
@@ -153,6 +153,23 @@ public class Account {
     this.aggregationMode = aggregationMode;
   }
 
+
+  public static List<String> getAccountSheetHeader() {
+    String[] accountData = { 
+      FormIdNames.ACCOUNT_ID, 
+      FormIdNames.VENDOR_ID, 
+      FormIdNames.ENTITY, 
+      FormIdNames.CURRENCY_CODE, 
+      FormIdNames.DIRECTION,
+      FormIdNames.LEGACY_ACCOUNT_ID,
+      FormIdNames.NEXT_GEN_ACCOUNT_ID,
+      FormIdNames.MATCHING_MODE,
+      FormIdNames.AGGREGATION_MODE
+    };
+
+    return Arrays.asList(accountData);
+  }
+
   /** Builds one row filled with an Account's data for the Sheet. */
   public List<String> getAccountSheetsRow(String vendorID) {
     String[] accountData = { 

--- a/src/main/java/data/SheetsConverter.java
+++ b/src/main/java/data/SheetsConverter.java
@@ -39,7 +39,9 @@ public class SheetsConverter {
 
   public void writeToSheet(ArrayList<Vendor> vendorList, Sheets sheetsService) 
     throws GeneralSecurityException, IOException {
-    HashMap<String, ArrayList<Account>> allAccounts = getAllAccounts(vendorList); 
+
+    HashMap<String, ArrayList<Account>> allAccounts = 
+      getAllAccounts(vendorList); 
 
     // Retrieve the latest spreadsheet data as a List<List<Object>> 
     // as required by the Sheets API.
@@ -67,9 +69,12 @@ public class SheetsConverter {
       .clear(SPREADSHEET_ID, TAB_2, requestBody).execute();
   } 
 
-  /** Gets every Account that is associated with any Vendor from the List. */
-  public HashMap<String, ArrayList<Account>> getAllAccounts(ArrayList<Vendor> vendors) {
-    HashMap<String, ArrayList<Account>> allAccounts =  new HashMap<String, ArrayList<Account>>();
+  /** Store the Accounts(value) associated to its Vendor(key) in a HashMap. */
+  public HashMap<String, ArrayList<Account>> getAllAccounts(
+    ArrayList<Vendor> vendors) {      
+
+    HashMap<String, ArrayList<Account>> allAccounts =  
+      new HashMap<String, ArrayList<Account>>();
 
     for(int i = 0; i < vendors.size(); i++) {
       allAccounts.put(vendors.get(i).getVendorID(), vendors.get(i).getAccounts());
@@ -78,7 +83,9 @@ public class SheetsConverter {
     return allAccounts; 
   }
 
-  public List<List<Object>> buildAccountSheetBody(HashMap<String, ArrayList<Account>> accounts) {
+  public List<List<Object>> buildAccountSheetBody(
+    HashMap<String, ArrayList<Account>> accounts) {
+
     // TODO: @cfloeder Sort the accounts by some criteria x. 
     List<List<Object>> accountSheetData = new ArrayList<List<Object>>();
     accountSheetData.add(new ArrayList<Object>(Account.getAccountSheetHeader()));
@@ -86,8 +93,8 @@ public class SheetsConverter {
     for(Map.Entry<String, ArrayList<Account>> entry : accounts.entrySet()) { 
       ArrayList<Account> accountList = entry.getValue();
       for(int i = 0; i < accountList.size(); i++) {
-        accountSheetData.add(new ArrayList<Object>(accountList.get(i).getAccountSheetsRow(
-        entry.getKey())));
+        accountSheetData.add(new ArrayList<Object>(accountList.get(i)
+        .getAccountSheetsRow(entry.getKey())));
       }
     }
 

--- a/src/main/java/data/SheetsConverter.java
+++ b/src/main/java/data/SheetsConverter.java
@@ -17,9 +17,7 @@ import com.google.api.services.sheets.v4.Sheets;
 import com.google.api.services.sheets.v4.model.*;
 import java.io.IOException;
 import java.security.GeneralSecurityException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
+import java.util.*;
 
 /** A class that updates the Account and Vendor spreadsheets. */
 public class SheetsConverter {
@@ -41,7 +39,7 @@ public class SheetsConverter {
 
   public void writeToSheet(ArrayList<Vendor> vendorList, Sheets sheetsService) 
     throws GeneralSecurityException, IOException {
-    ArrayList<ArrayList<Account>> allAccounts = getAllAccounts(vendorList); 
+    HashMap<String, ArrayList<Account>> allAccounts = getAllAccounts(vendorList); 
 
     // Retrieve the latest spreadsheet data as a List<List<Object>> 
     // as required by the Sheets API.
@@ -70,27 +68,28 @@ public class SheetsConverter {
   } 
 
   /** Gets every Account that is associated with any Vendor from the List. */
-  public ArrayList<ArrayList<Account>> getAllAccounts(ArrayList<Vendor> vendors) {
-    ArrayList<ArrayList<Account>> allAccounts =  new ArrayList<ArrayList<Account>>();
+  public HashMap<String, ArrayList<Account>> getAllAccounts(ArrayList<Vendor> vendors) {
+    HashMap<String, ArrayList<Account>> allAccounts =  new HashMap<String, ArrayList<Account>>();
 
     for(int i = 0; i < vendors.size(); i++) {
-      allAccounts.add(vendors.get(i).getAccounts());
+      allAccounts.put(vendors.get(i).getVendorID(), vendors.get(i).getAccounts());
     }
 
     return allAccounts; 
   }
 
-  public List<List<Object>> buildAccountSheetBody(ArrayList<ArrayList<Account>> accounts) {
+  public List<List<Object>> buildAccountSheetBody(HashMap<String, ArrayList<Account>> accounts) {
     // TODO: @cfloeder Sort the accounts by some criteria x. 
     List<List<Object>> accountSheetData = new ArrayList<List<Object>>();
 
-    for(int i = 0; i < accounts.size(); i++) {
-      for(int j = 0; j < accounts.get(i).size(); j++) {
-        accountSheetData.add(new ArrayList<Object>(accounts.get(i).get(j).
-          getAccountSheetsRow()));
+    for(Map.Entry<String, ArrayList<Account>> entry : accounts.entrySet()) { 
+      ArrayList<Account> accountList = entry.getValue();
+      for(int i = 0; i < accountList.size(); i++) {
+        accountSheetData.add(new ArrayList<Object>(accountList.get(i).getAccountSheetsRow(
+        entry.getKey())));
       }
     }
-    
+
     return accountSheetData;
   }
 

--- a/src/main/java/data/SheetsConverter.java
+++ b/src/main/java/data/SheetsConverter.java
@@ -17,7 +17,10 @@ import com.google.api.services.sheets.v4.Sheets;
 import com.google.api.services.sheets.v4.model.*;
 import java.io.IOException;
 import java.security.GeneralSecurityException;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.HashMap;
 
 /** A class that updates the Account and Vendor spreadsheets. */
 public class SheetsConverter {

--- a/src/main/java/data/SheetsConverter.java
+++ b/src/main/java/data/SheetsConverter.java
@@ -81,6 +81,7 @@ public class SheetsConverter {
   public List<List<Object>> buildAccountSheetBody(HashMap<String, ArrayList<Account>> accounts) {
     // TODO: @cfloeder Sort the accounts by some criteria x. 
     List<List<Object>> accountSheetData = new ArrayList<List<Object>>();
+    accountSheetData.add(new ArrayList<Object>(Account.getAccountSheetHeader()));
 
     for(Map.Entry<String, ArrayList<Account>> entry : accounts.entrySet()) { 
       ArrayList<Account> accountList = entry.getValue();
@@ -96,6 +97,7 @@ public class SheetsConverter {
   public List<List<Object>> buildVendorSheetBody(ArrayList<Vendor> vendors) {
     // TODO: @cfloeder Sort the vendors by some criteria x. 
     List<List<Object>> vendorSheetData = new ArrayList<List<Object>>();
+    vendorSheetData.add(new ArrayList<Object>(Vendor.getVendorSheetHeader()));
 
     for(int i = 0; i < vendors.size(); i++) {
       vendorSheetData.add(new ArrayList<Object>(vendors.get(i).

--- a/src/main/java/data/SheetsConverter.java
+++ b/src/main/java/data/SheetsConverter.java
@@ -31,14 +31,14 @@ public class SheetsConverter {
   private final String INPUT_OPTION = "RAW";
 
   public void updateSheets(ArrayList<Vendor> vendorList, String accessToken) 
-    throws GeneralSecurityException, IOException {
+      throws GeneralSecurityException, IOException {
     sheetsService = SheetsServiceUtil.getSheetsService(accessToken);
     clearSheets(sheetsService);
     writeToSheet(vendorList, sheetsService); 
   }
 
   public void writeToSheet(ArrayList<Vendor> vendorList, Sheets sheetsService) 
-    throws GeneralSecurityException, IOException {
+      throws GeneralSecurityException, IOException {
 
     HashMap<String, ArrayList<Account>> allAccounts = 
       getAllAccounts(vendorList); 
@@ -71,7 +71,7 @@ public class SheetsConverter {
 
   /** Store the Accounts(value) associated to its Vendor(key) in a HashMap. */
   public HashMap<String, ArrayList<Account>> getAllAccounts(
-    ArrayList<Vendor> vendors) {      
+      ArrayList<Vendor> vendors) {      
 
     HashMap<String, ArrayList<Account>> allAccounts =  
       new HashMap<String, ArrayList<Account>>();
@@ -84,7 +84,7 @@ public class SheetsConverter {
   }
 
   public List<List<Object>> buildAccountSheetBody(
-    HashMap<String, ArrayList<Account>> accounts) {
+      HashMap<String, ArrayList<Account>> accounts) {
 
     // TODO: @cfloeder Sort the accounts by some criteria x. 
     List<List<Object>> accountSheetData = new ArrayList<List<Object>>();

--- a/src/main/java/data/Vendor.java
+++ b/src/main/java/data/Vendor.java
@@ -126,7 +126,8 @@ public class Vendor {
       getNextGenVendorID());
 
     if (!accounts.isEmpty()) {
-      config += accounts.stream().map(Account::buildJsonConfig).collect(Collectors.joining(","));
+      config += accounts.stream().map(Account::buildJsonConfig)
+        .collect(Collectors.joining(","));
     }
     config += "]}";
     return config;

--- a/src/main/java/data/Vendor.java
+++ b/src/main/java/data/Vendor.java
@@ -97,6 +97,16 @@ public class Vendor {
     return accountList;
   }
 
+  public static List<String> getVendorSheetHeader() {
+    String[] accountData = {  
+      FormIdNames.VENDOR_ID, 
+      FormIdNames.LEGACY_CUSTOMER_ID,
+      FormIdNames.NEXT_GEN_CUSTOMER_ID
+    };
+
+    return Arrays.asList(accountData);
+  }
+
   /** Builds one row filled with an Vendor's data for the Sheet. */
   public List<String> getVendorSheetsRow() {
     String[] vendorData = { 

--- a/src/main/webapp/editfile.html
+++ b/src/main/webapp/editfile.html
@@ -32,7 +32,7 @@
     </div><br>
     <div id="edit-form">
       <form id="edit-config-form" method="post" onsubmit="return validateEditFormInput();">
-        <span>Legacy Customer ID:</span>
+        <label for="legacy-customer-id">Legacy Customer ID:</label>
         <input type="text" id="legacy-customer-id" name="legacy-customer-id"><br>
         <label for="next-gen-customer-id">Next Gen Customer ID:</label>
         <input type="text" id="next-gen-customer-id" name="next-gen-customer-id"><br>

--- a/src/main/webapp/readfile.html
+++ b/src/main/webapp/readfile.html
@@ -27,7 +27,7 @@
       </select><br>
       <p>Account ID:</p>
       <select id="account-ids">
-      </select><br>
+      </select><br><br>
       <button type="submit">Choose configuration</button>
     </form>
     </div><br>

--- a/src/test/java/AccountTest.java
+++ b/src/test/java/AccountTest.java
@@ -112,7 +112,7 @@ public final class AccountTest {
     };
     List<String> expectedResponse = Arrays.asList(expectedArray);
 
-    List<String> actualResponse = account.getAccountSheetsRow();
+    List<String> actualResponse = account.getAccountSheetsRow(VENDOR_ID);
 
     assertEquals(expectedResponse, actualResponse);
   }

--- a/src/test/java/AccountTest.java
+++ b/src/test/java/AccountTest.java
@@ -15,6 +15,7 @@
 package javatests;
 
 import data.Account;
+import util.FormIdNames;
 import org.json.JSONObject;
 import org.junit.Before;
 import org.junit.Test;
@@ -101,6 +102,27 @@ public final class AccountTest {
 
     assertTrue(expected.similar(actual));
     assertEquals("Failed to construct Account object from JSON", expectedResponse, actualResponse);
+  }
+
+  /** Test that getAccountSheetHeader returns the correct Account headings. */
+  @Test
+  public void testGetAccountSheetHeader() {
+    String[] expectedArray = {
+      FormIdNames.ACCOUNT_ID, 
+      FormIdNames.VENDOR_ID, 
+      FormIdNames.ENTITY, 
+      FormIdNames.CURRENCY_CODE, 
+      FormIdNames.DIRECTION,
+      FormIdNames.LEGACY_ACCOUNT_ID,
+      FormIdNames.NEXT_GEN_ACCOUNT_ID,
+      FormIdNames.MATCHING_MODE,
+      FormIdNames.AGGREGATION_MODE
+    };
+    List<String> expectedResponse = Arrays.asList(expectedArray);
+
+    List<String> actualResponse = Account.getAccountSheetHeader();
+
+    assertEquals(expectedResponse, actualResponse);
   }
 
   /** Test that getAccountSheetsRow returns a List representing its data. */

--- a/src/test/java/SheetsConverterTest.java
+++ b/src/test/java/SheetsConverterTest.java
@@ -80,35 +80,35 @@ public final class SheetsConverterTest {
   /** Check that buildAccountSheetBody returns a List with expected data. */
   @Test
   public void testBuildAccountSheetBody() throws GeneralSecurityException, IOException{
-    vendor.addAccount(account);
-    ArrayList<Vendor> vendors = new ArrayList<Vendor>();
-    vendors.add(vendor);
+    // vendor.addAccount(account);
+    // ArrayList<Vendor> vendors = new ArrayList<Vendor>();
+    // vendors.add(vendor);
 
-    Object[] expectedArray = {
-      ACCOUNT_ID, VENDOR_ID, ENTITY, CURRENCY, DIRECTION, LEGACY_ACCOUNT_ID,
-      Integer.toString(NEXT_GEN_ACCOUNT_ID), MATCHING_MODE, AGGREGATION_MODE
-    };
-    List<List<Object>> expectedResponse = Arrays.asList(Arrays.asList(expectedArray));
+    // Object[] expectedArray = {
+    //   ACCOUNT_ID, VENDOR_ID, ENTITY, CURRENCY, DIRECTION, LEGACY_ACCOUNT_ID,
+    //   Integer.toString(NEXT_GEN_ACCOUNT_ID), MATCHING_MODE, AGGREGATION_MODE
+    // };
+    // List<List<Object>> expectedResponse = Arrays.asList(Arrays.asList(expectedArray));
 
-    List<List<Object>> actualResponse = converter.buildAccountSheetBody(
-      converter.getAllAccounts(vendors));
+    // List<List<Object>> actualResponse = converter.buildAccountSheetBody(
+    //   converter.getAllAccounts(vendors));
       
-    assertEquals(expectedResponse, actualResponse);
+    // assertEquals(expectedResponse, actualResponse);
   }
   
   /** Check that buildVendorSheetBody returns a List with expected data. */
   @Test
   public void testBuildVendorSheetBody() throws GeneralSecurityException, IOException{
-    ArrayList<Vendor> vendors = new ArrayList<Vendor>();
-    vendors.add(vendor);
+    // ArrayList<Vendor> vendors = new ArrayList<Vendor>();
+    // vendors.add(vendor);
 
-    Object[] expectedArray = {
-      VENDOR_ID, LEGACY_VENDOR_ID, Integer.toString(NEXT_GEN_VENDOR_ID)
-    };
-    List<List<Object>> expectedResponse = Arrays.asList(Arrays.asList(expectedArray));
+    // Object[] expectedArray = {
+    //   VENDOR_ID, LEGACY_VENDOR_ID, Integer.toString(NEXT_GEN_VENDOR_ID)
+    // };
+    // List<List<Object>> expectedResponse = Arrays.asList(Arrays.asList(expectedArray));
 
-    List<List<Object>> actualResponse = converter.buildVendorSheetBody(vendors);
+    // List<List<Object>> actualResponse = converter.buildVendorSheetBody(vendors);
       
-    assertEquals(expectedResponse, actualResponse);
+    // assertEquals(expectedResponse, actualResponse);
   }
 }

--- a/src/test/java/SheetsConverterTest.java
+++ b/src/test/java/SheetsConverterTest.java
@@ -67,11 +67,11 @@ public final class SheetsConverterTest {
     ArrayList<Vendor> vendors = new ArrayList<Vendor>();
     vendors.add(vendor);
 
-    ArrayList<ArrayList<Account>> expectedResponse = new 
-      ArrayList<ArrayList<Account>>();
-    expectedResponse.add(vendor.getAccounts());
+    HashMap<String, ArrayList<Account>> expectedResponse = new 
+       HashMap<String, ArrayList<Account>>();
+    expectedResponse.put(VENDOR_ID, vendor.getAccounts());
 
-    ArrayList<ArrayList<Account>> actualResponse = converter.
+    HashMap<String, ArrayList<Account>> actualResponse = converter.
       getAllAccounts(vendors);
     
     assertEquals(expectedResponse, actualResponse);

--- a/src/test/java/SheetsConverterTest.java
+++ b/src/test/java/SheetsConverterTest.java
@@ -80,35 +80,39 @@ public final class SheetsConverterTest {
   /** Check that buildAccountSheetBody returns a List with expected data. */
   @Test
   public void testBuildAccountSheetBody() throws GeneralSecurityException, IOException{
-    // vendor.addAccount(account);
-    // ArrayList<Vendor> vendors = new ArrayList<Vendor>();
-    // vendors.add(vendor);
+    vendor.addAccount(account);
+    ArrayList<Vendor> vendors = new ArrayList<Vendor>();
+    vendors.add(vendor);
 
-    // Object[] expectedArray = {
-    //   ACCOUNT_ID, VENDOR_ID, ENTITY, CURRENCY, DIRECTION, LEGACY_ACCOUNT_ID,
-    //   Integer.toString(NEXT_GEN_ACCOUNT_ID), MATCHING_MODE, AGGREGATION_MODE
-    // };
-    // List<List<Object>> expectedResponse = Arrays.asList(Arrays.asList(expectedArray));
+    Object[] expectedArray = {
+      ACCOUNT_ID, VENDOR_ID, ENTITY, CURRENCY, DIRECTION, LEGACY_ACCOUNT_ID,
+      Integer.toString(NEXT_GEN_ACCOUNT_ID), MATCHING_MODE, AGGREGATION_MODE
+    };
+    List<List<Object>> expectedResponse = new ArrayList<List<Object>>();
+    expectedResponse.add(new ArrayList<Object>(Account.getAccountSheetHeader()));
+    expectedResponse.add(new ArrayList<Object>(Arrays.asList(expectedArray)));
 
-    // List<List<Object>> actualResponse = converter.buildAccountSheetBody(
-    //   converter.getAllAccounts(vendors));
+    List<List<Object>> actualResponse = converter.buildAccountSheetBody(
+      converter.getAllAccounts(vendors));
       
-    // assertEquals(expectedResponse, actualResponse);
+    assertEquals(expectedResponse, actualResponse);
   }
   
   /** Check that buildVendorSheetBody returns a List with expected data. */
   @Test
   public void testBuildVendorSheetBody() throws GeneralSecurityException, IOException{
-    // ArrayList<Vendor> vendors = new ArrayList<Vendor>();
-    // vendors.add(vendor);
+    ArrayList<Vendor> vendors = new ArrayList<Vendor>();
+    vendors.add(vendor);
 
-    // Object[] expectedArray = {
-    //   VENDOR_ID, LEGACY_VENDOR_ID, Integer.toString(NEXT_GEN_VENDOR_ID)
-    // };
-    // List<List<Object>> expectedResponse = Arrays.asList(Arrays.asList(expectedArray));
+    Object[] expectedArray = {
+      VENDOR_ID, LEGACY_VENDOR_ID, Integer.toString(NEXT_GEN_VENDOR_ID)
+    };
+    List<List<Object>> expectedResponse = new ArrayList<List<Object>>();
+    expectedResponse.add(new ArrayList<Object>(Vendor.getVendorSheetHeader()));
+    expectedResponse.add(new ArrayList<Object>(Arrays.asList(expectedArray)));
 
-    // List<List<Object>> actualResponse = converter.buildVendorSheetBody(vendors);
+    List<List<Object>> actualResponse = converter.buildVendorSheetBody(vendors);
       
-    // assertEquals(expectedResponse, actualResponse);
+    assertEquals(expectedResponse, actualResponse);
   }
 }

--- a/src/test/java/VendorTest.java
+++ b/src/test/java/VendorTest.java
@@ -24,6 +24,7 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertEquals;
 import data.Account;
 import data.Vendor;
+import util.FormIdNames;
 
 @RunWith(JUnit4.class)
 public final class VendorTest {
@@ -92,6 +93,21 @@ public final class VendorTest {
       LEGACY_ACCOUNT_ID, NEXT_GEN_ACCOUNT_ID, CURRENCY, DIRECTION, ENTITY, 
       MATCHING_MODE, ACCOUNT_ID,AGGREGATION_MODE);
     String actualResponse = vendor.buildJsonConfig();
+
+    assertEquals(expectedResponse, actualResponse);
+  }
+
+  /** Test that getVendorSheetHeader returns the correct Vendor headings. */
+  @Test
+  public void testGetAccountSheetHeader() {
+    String[] expectedArray = {
+      FormIdNames.VENDOR_ID, 
+      FormIdNames.LEGACY_CUSTOMER_ID,
+      FormIdNames.NEXT_GEN_CUSTOMER_ID,
+    };
+    List<String> expectedResponse = Arrays.asList(expectedArray);
+
+    List<String> actualResponse = Vendor.getVendorSheetHeader();
 
     assertEquals(expectedResponse, actualResponse);
   }


### PR DESCRIPTION
I realized that the vendorIds for the accounts weren't being written to the Account sheet because its value was null. I restructured some things to pass in the Account's VendorID when creating the contents of the sheet. I updated the tests for the effected methods. Then, I added methods that create the headers for the Account and Vendor sheets. I also tested these methods.