### PR TITLE
Move Dropmenu farther to the right.

### DIFF
--- a/src/main/webapp/assets/common.css
+++ b/src/main/webapp/assets/common.css
@@ -21,18 +21,18 @@ select {
 
 /* Creates a dropdown page menu */
 .drop_menu {
-    position: absolute;
-    right: 475px;
-    display: inline-block;
+  position: absolute;
+  right: 200px;
+  display: inline-block;
 }
 
 .menu_button {
-    background-color: rgb(241, 241, 241);
-    color: black;
-    min-width: 150px;
-    padding: 5px;
-    font-size: 16px;
-    border: none;
+  background-color: rgb(241, 241, 241);
+  color: black;
+  min-width: 150px;
+  padding: 5px;
+  font-size: 16px;
+  border: none;
 }
 
 .dropdown_content {


### PR DESCRIPTION
There was an issue on smaller screens with the dropmenu covering up some content. I fixed this by moving the menu farther to the right. While this won't allow for use by super small screen sizes like phones, it should work for all laptops/computers.