### PR TITLE
Send data from edit form to spreadsheet

### DIFF
--- a/src/main/java/data/JsonConverter.java
+++ b/src/main/java/data/JsonConverter.java
@@ -35,12 +35,21 @@ public class JsonConverter {
     basePath = filePathName;
   }
 
+  /**
+   * Checks to see if a vendor's configuration already exists, and updates
+   * it if it does
+   * @param vendor Vendor to update configuration
+   * @return configuration write status
+   */
   public boolean updateFile(Vendor vendor) {
-    String jsonConfig = vendor.buildJsonConfig();
     // Create and write the contents to a File.
-    File billingFile = writeFile(vendor.getVendorID(), jsonConfig);
-
-    return billingFile != null;
+    if (!configExists(vendor.getVendorID())) {
+      return false;
+    } else {
+      String jsonConfig = vendor.buildJsonConfig();
+      File config = writeFile(vendor.getVendorID(), jsonConfig);
+      return true;
+    }
   }
 
   /**
@@ -119,6 +128,10 @@ public class JsonConverter {
   public ArrayList<String> getVendorIDs() {
     File root = new File(basePath);
     return new ArrayList<String>(Arrays.asList(Objects.requireNonNull(root.list())));
+  }
+
+  public boolean configExists(String vendorID) {
+    return getVendorIDs().contains(vendorID);
   }
 
   /**

--- a/src/main/java/data/JsonConverter.java
+++ b/src/main/java/data/JsonConverter.java
@@ -19,7 +19,6 @@ import java.util.*;
 
 import com.google.gson.Gson;
 import org.json.JSONArray;
-import org.json.JSONObject;
 
 /** A class that creates a config file from a Vendor object. */
 public class JsonConverter {

--- a/src/main/java/data/JsonConverter.java
+++ b/src/main/java/data/JsonConverter.java
@@ -36,7 +36,8 @@ public class JsonConverter {
 
   /**
    * Checks to see if a vendor's configuration already exists, and updates
-   * it if it does.
+   * it if it does. If a configuration does not exist, return false
+   * without writing changes.
    * @param vendor Vendor to update configuration
    * @return configuration write status
    */

--- a/src/main/java/data/JsonConverter.java
+++ b/src/main/java/data/JsonConverter.java
@@ -36,7 +36,7 @@ public class JsonConverter {
 
   /**
    * Checks to see if a vendor's configuration already exists, and updates
-   * it if it does
+   * it if it does.
    * @param vendor Vendor to update configuration
    * @return configuration write status
    */

--- a/src/main/java/servlets/BillingConfig.java
+++ b/src/main/java/servlets/BillingConfig.java
@@ -16,16 +16,13 @@ package servlets;
 import data.JsonConverter;
 import data.Vendor;
 import data.Account;
-import data.SheetsConverter;
 
 import java.io.IOException;
-import java.util.ArrayList;
 import java.security.GeneralSecurityException;
 import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import javax.servlet.http.HttpSession;
 import util.FormIdNames;
 
 import static servlets.VendorServlet.updateSheets;
@@ -40,8 +37,6 @@ public class BillingConfig extends HttpServlet {
 
   @Override
   public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException{
-    // GET method --> returns entire billing config as JSON
-    // return null if vendor ID doesn't exist
     String vendorID = request.getParameter(FormIdNames.VENDOR_ID);
     String accountID = request.getParameter(FormIdNames.ACCOUNT_ID);
 
@@ -67,7 +62,8 @@ public class BillingConfig extends HttpServlet {
       if (jsonConverter.updateFile(newVendor)) {
         // Update Google sheets following update file.
         updateSheets(request);
-        // Redirect only when the operation succeeded
+
+        // Redirect only when the operation succeeded.
         response.getWriter().println(newVendor.getVendorID());
         response.sendRedirect(REDIRECT_READFILE);
       } else {

--- a/src/main/java/servlets/BillingConfig.java
+++ b/src/main/java/servlets/BillingConfig.java
@@ -18,21 +18,17 @@ import data.Vendor;
 import data.Account;
 import data.SheetsConverter;
 
-import java.io.File;
 import java.io.IOException;
-import java.lang.reflect.Array;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.security.GeneralSecurityException;
-import java.util.Enumeration;
-import java.util.stream.Collectors;
 import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpSession;
-import com.google.api.client.googleapis.auth.oauth2.GoogleCredential;
 import util.FormIdNames;
+
+import static servlets.VendorServlet.updateSheets;
 
 @WebServlet("/BillingConfig")
 public class BillingConfig extends HttpServlet {
@@ -98,8 +94,13 @@ public class BillingConfig extends HttpServlet {
       } else {
         response.sendError(400, "Something went wrong when we tried to write your file.");
       }
+      // Update Google sheets following update file.
+      updateSheets(request);
     } catch(NumberFormatException e) {
       response.sendError(400, "A NumberFormatException occurred.");
+    } catch(GeneralSecurityException e) {
+      response.sendError(400, "A GeneralSecurityException occurred. Make sure you have authorized" +
+              "the Google Sheets API.");
     }
   }
 }

--- a/src/main/java/servlets/BillingConfig.java
+++ b/src/main/java/servlets/BillingConfig.java
@@ -78,6 +78,8 @@ public class BillingConfig extends HttpServlet {
     } catch(GeneralSecurityException e) {
       response.sendError(400, "A GeneralSecurityException occurred. Make sure you have authorized" +
               "the Google Sheets API.");
+    } catch(IllegalStateException | NullPointerException e) {
+      response.sendError(400, "Your OAuth token has expired. Visit /OAuth to refresh");
     }
   }
 }

--- a/src/main/java/servlets/BillingConfig.java
+++ b/src/main/java/servlets/BillingConfig.java
@@ -68,11 +68,11 @@ public class BillingConfig extends HttpServlet {
         // Redirect only when the operation succeeded
         response.getWriter().println(newVendor.getVendorID());
         response.sendRedirect(REDIRECT_READFILE);
+        // Update Google sheets following update file.
+        updateSheets(request);
       } else {
         response.sendError(400, "Something went wrong when we tried to write your file.");
       }
-      // Update Google sheets following update file.
-      updateSheets(request);
     } catch(NumberFormatException e) {
       response.sendError(400, "A NumberFormatException occurred.");
     } catch(GeneralSecurityException e) {

--- a/src/main/java/servlets/BillingConfig.java
+++ b/src/main/java/servlets/BillingConfig.java
@@ -54,29 +54,6 @@ public class BillingConfig extends HttpServlet {
       configText = "Error finding " + vendorID + "'s configuration";
     }
 
-    /** 
-     * TODO: @cade, eventually you will want to pass this access token and 
-     * Vendor List into the updateSheets() method in the SheetsConverter class.
-     */
-    // Only retrieves the session if one exists.
-    HttpSession session = request.getSession(false);
-    String accessToken = session.getAttribute("accessToken").toString();
-
-    SheetsConverter sheet = new SheetsConverter();
-    try {
-      // Use hard-coded values to test writeToSheets method.
-      ArrayList<Vendor> vendors = new ArrayList<Vendor>();
-      vendor = new Vendor("vend_1", "legVend_27", 17);
-      account = new Account("acc_12", "vend_1", "shopper", "USD", "disbursement",
-            "legAcc_53", 17, "straight", "totalAgg");
-      vendor.addAccount(account);
-      vendors.add(vendor);
-
-      sheet.updateSheets(vendors, accessToken);
-    } catch (GeneralSecurityException e) {
-      // TODO: @cade Figure out how you want to handle this error.
-    }
-
     response.setContentType(CONTENT_TYPE_APPLICATION_JSON);
     response.getWriter().println(configText);
   }

--- a/src/main/java/servlets/BillingConfig.java
+++ b/src/main/java/servlets/BillingConfig.java
@@ -65,13 +65,13 @@ public class BillingConfig extends HttpServlet {
       Vendor newVendor = new Vendor(request);
       JsonConverter jsonConverter = new JsonConverter();
       if (jsonConverter.updateFile(newVendor)) {
+        // Update Google sheets following update file.
+        updateSheets(request);
         // Redirect only when the operation succeeded
         response.getWriter().println(newVendor.getVendorID());
         response.sendRedirect(REDIRECT_READFILE);
-        // Update Google sheets following update file.
-        updateSheets(request);
       } else {
-        response.sendError(400, "Something went wrong when we tried to write your file.");
+        response.sendError(400, "This configuration does not exist.");
       }
     } catch(NumberFormatException e) {
       response.sendError(400, "A NumberFormatException occurred.");

--- a/src/main/java/servlets/VendorServlet.java
+++ b/src/main/java/servlets/VendorServlet.java
@@ -86,7 +86,7 @@ public class VendorServlet extends HttpServlet {
 
   /** Rebuild the sheets without the deleted Vendor's data. */
   public static void updateSheets(HttpServletRequest request) throws
-          IOException, GeneralSecurityException, IllegalStateException {
+          IOException, GeneralSecurityException, IllegalStateException, NullPointerException {
 
     JsonConverter converter = new JsonConverter();
     ArrayList<String> vendorIDs = converter.getVendorIDs();

--- a/src/main/java/servlets/VendorServlet.java
+++ b/src/main/java/servlets/VendorServlet.java
@@ -78,7 +78,7 @@ public class VendorServlet extends HttpServlet {
     ArrayList<String> vendorIDs = converter.getVendorIDs();
 
     // Validate that the vendorID exists.
-    if(!vendorIDs.contains(vendorID)) {
+    if (!vendorIDs.contains(vendorID)) {
         throw new FileNotFoundException();
     }
     converter.deleteFile(vendorID);
@@ -99,16 +99,15 @@ public class VendorServlet extends HttpServlet {
       SheetsConverter sheets = new SheetsConverter();
       sheets.updateSheets(vendors, accessToken);
     } else {
-      throw new IllegalStateException("OAuth has not yet been set");
+      throw new IllegalStateException();
     }
-
   }
 
   private static ArrayList<Vendor> getVendors(ArrayList<String> vendorIDs,
       JsonConverter converter) throws IOException {
     ArrayList<Vendor> vendors = new ArrayList<Vendor>();
 
-    for(int i = 0; i < vendorIDs.size(); i++) {
+    for (int i = 0; i < vendorIDs.size(); i++) {
       String vendorJson = converter.getConfig(vendorIDs.get(i));
       vendors.add(new Vendor(vendorJson, vendorIDs.get(i)));
     }

--- a/src/main/java/servlets/VendorServlet.java
+++ b/src/main/java/servlets/VendorServlet.java
@@ -34,7 +34,7 @@ public class VendorServlet extends HttpServlet {
   private static final String JSON_TYPE = "application/json;";
   private final String DELETE_PAGE_REDIRECT = "/deletefile.html";
   private final String VENDOR_ID_PARAM = "vendorID";
-  private final String TOKEN_ATTRIBUTE = "accessToken";
+  private static final String TOKEN_ATTRIBUTE = "accessToken";
 
   @Override
   /**
@@ -57,7 +57,7 @@ public class VendorServlet extends HttpServlet {
     throws IOException {  
     String vendorID = request.getParameter(VENDOR_ID_PARAM);
     String responseString = String.format(
-      "Config with VendorID:%s was successfuly deleted.", vendorID); 
+      "Config with VendorID:%s was successfully deleted.", vendorID);
 
     // Delete the file from the filesystem and update the sheets.
     try {
@@ -85,8 +85,9 @@ public class VendorServlet extends HttpServlet {
   }
 
   /** Rebuild the sheets without the deleted Vendor's data. */
-  private void updateSheets(HttpServletRequest request) 
-      throws IOException, GeneralSecurityException {
+  public static void updateSheets(HttpServletRequest request) throws
+          IOException, GeneralSecurityException {
+
     JsonConverter converter = new JsonConverter();
     ArrayList<String> vendorIDs = converter.getVendorIDs();
     ArrayList<Vendor> vendors = getVendors(vendorIDs, converter); 
@@ -99,9 +100,9 @@ public class VendorServlet extends HttpServlet {
     sheets.updateSheets(vendors, accessToken);
   }
 
-  public ArrayList<Vendor> getVendors(ArrayList<String> vendorIDs, 
+  private static ArrayList<Vendor> getVendors(ArrayList<String> vendorIDs,
       JsonConverter converter) throws IOException {
-    ArrayList<Vendor> vendors = new ArrayList<Vendor>(); 
+    ArrayList<Vendor> vendors = new ArrayList<Vendor>();
 
     for(int i = 0; i < vendorIDs.size(); i++) {
       String vendorJson = converter.getConfig(vendorIDs.get(i));

--- a/src/main/java/servlets/VendorServlet.java
+++ b/src/main/java/servlets/VendorServlet.java
@@ -57,7 +57,7 @@ public class VendorServlet extends HttpServlet {
     throws IOException {  
     String vendorID = request.getParameter(VENDOR_ID_PARAM);
     String responseString = String.format(
-      "Config with VendorID:%s was successfully deleted.", vendorID);
+      "Config with VendorID: %s was successfully deleted.", vendorID);
 
     // Delete the file from the filesystem and update the sheets.
     try {

--- a/src/main/java/servlets/VendorServlet.java
+++ b/src/main/java/servlets/VendorServlet.java
@@ -86,7 +86,7 @@ public class VendorServlet extends HttpServlet {
 
   /** Rebuild the sheets without the deleted Vendor's data. */
   public static void updateSheets(HttpServletRequest request) throws
-          IOException, GeneralSecurityException {
+          IOException, GeneralSecurityException, IllegalStateException {
 
     JsonConverter converter = new JsonConverter();
     ArrayList<String> vendorIDs = converter.getVendorIDs();
@@ -94,10 +94,14 @@ public class VendorServlet extends HttpServlet {
 
     // Only retrieve the session if one exists.
     HttpSession session = request.getSession(false);
-    String accessToken = session.getAttribute(TOKEN_ATTRIBUTE).toString();
+    if (session != null) {
+      String accessToken = session.getAttribute(TOKEN_ATTRIBUTE).toString();
+      SheetsConverter sheets = new SheetsConverter();
+      sheets.updateSheets(vendors, accessToken);
+    } else {
+      throw new IllegalStateException("OAuth has not yet been set");
+    }
 
-    SheetsConverter sheets = new SheetsConverter();
-    sheets.updateSheets(vendors, accessToken);
   }
 
   private static ArrayList<Vendor> getVendors(ArrayList<String> vendorIDs,

--- a/src/test/java/JsonConverterTest.java
+++ b/src/test/java/JsonConverterTest.java
@@ -47,6 +47,8 @@ public final class JsonConverterTest {
   private final int NEXT_GEN_ACCOUNT_ID = 17;
   private final String MATCHING_MODE = "straight";
   private final String AGGREGATION_MODE = "totalAgg";
+  private final String FAKE_VENDOR_ID = "fake_id";
+
 
   /** Create a Vendor and Account object. */
   @Before
@@ -61,12 +63,20 @@ public final class JsonConverterTest {
   /** Test that updateFile() returns true. */
   @Test
   public void testUpdateFileMethod() throws IOException {
-
     boolean expectedResponse = true;
     boolean actualResponse = converter.updateFile(vendor);
 
-    assertTrue("updateFile() didn't return true when it should have.",
-            expectedResponse == actualResponse);
+    assertEquals("updateFile() refused to update existing file.",
+            expectedResponse, actualResponse);
+  }
+
+  @Test
+  public void testUpdateNonexistentFile() {
+    boolean expected = false;
+    boolean actual = converter.updateFile(new Vendor(FAKE_VENDOR_ID,
+            LEGACY_VENDOR_ID, NEXT_GEN_VENDOR_ID));
+    assertEquals("updateFile() updated file that does not exist",
+            expected, actual);
   }
 
   /**


### PR DESCRIPTION
### Description
This PR finishes TODOs from #61. The webpage will only accept edits from vendor/account combos that already exist, and then pushes the changes to the spreadsheet. A NullPointerException previously was thrown if OAuth had not been set up, and this PR catches that problem and gives a more descriptive error

### Issues Resolved
- Closes #72 