### PR TITLE
Support adding new accounts and editing existing accounts

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -87,7 +87,7 @@
       <scope>test</scope>
     </dependency>
 
-    <dependency>
+    <dependency> <!-- gives access to mockito framework for testing -->
       <groupId>org.mockito</groupId>
       <artifactId>mockito-all</artifactId>
       <version>1.10.19</version>

--- a/pom.xml
+++ b/pom.xml
@@ -87,6 +87,12 @@
       <scope>test</scope>
     </dependency>
 
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-all</artifactId>
+      <version>1.10.19</version>
+    </dependency>
+
   </dependencies>
 
   <build>

--- a/src/main/java/data/Account.java
+++ b/src/main/java/data/Account.java
@@ -197,7 +197,10 @@ public class Account {
       getAccountID(), getAggregationMode());
   }
 
-  public void update(HttpServletRequest request) {
+  /**
+   * @param request a request containing form data to edit existing account
+   */
+  public void updateExistingAccount(HttpServletRequest request) {
     this.vendorID = request.getParameter(FormIdNames.VENDOR_ID);
     this.accountID = request.getParameter(FormIdNames.ACCOUNT_ID);
     this.legacyAccountID = request.getParameter(FormIdNames.LEGACY_ACCOUNT_ID);

--- a/src/main/java/data/Account.java
+++ b/src/main/java/data/Account.java
@@ -196,4 +196,17 @@ public class Account {
       getCurrency(), getDirection(), getEntity(), getMatchingMode(), 
       getAccountID(), getAggregationMode());
   }
+
+  public void update(HttpServletRequest request) {
+    this.vendorID = request.getParameter(FormIdNames.VENDOR_ID);
+    this.accountID = request.getParameter(FormIdNames.ACCOUNT_ID);
+    this.legacyAccountID = request.getParameter(FormIdNames.LEGACY_ACCOUNT_ID);
+    this.nextGenAccountID = Integer.parseInt(
+            request.getParameter(FormIdNames.NEXT_GEN_ACCOUNT_ID));
+    this.currency = request.getParameter(FormIdNames.CURRENCY_CODE);
+    this.direction = request.getParameter(FormIdNames.DIRECTION);
+    this.entity = request.getParameter(FormIdNames.ENTITY);
+    this.matchingMode = request.getParameter(FormIdNames.MATCHING_MODE);
+    this.aggregationMode = request.getParameter(FormIdNames.AGGREGATION_MODE);
+  }
 }

--- a/src/main/java/data/Account.java
+++ b/src/main/java/data/Account.java
@@ -198,7 +198,7 @@ public class Account {
   }
 
   /**
-   * @param request a request containing form data to edit existing account
+   * @param request contains form data to edit existing account
    */
   public void updateExistingAccount(HttpServletRequest request) {
     this.vendorID = request.getParameter(FormIdNames.VENDOR_ID);

--- a/src/main/java/data/Account.java
+++ b/src/main/java/data/Account.java
@@ -90,7 +90,7 @@ public class Account {
   }
 
   public String getVendorID() {
-    return vendorID;  
+    return vendorID;
   }
 
   public void setVendorID(String vendorID) {
@@ -154,11 +154,11 @@ public class Account {
   }
 
   public static List<String> getAccountSheetHeader() {
-    String[] accountData = { 
-      FormIdNames.ACCOUNT_ID, 
-      FormIdNames.VENDOR_ID, 
-      FormIdNames.ENTITY, 
-      FormIdNames.CURRENCY_CODE, 
+    String[] accountData = {
+      FormIdNames.ACCOUNT_ID,
+      FormIdNames.VENDOR_ID,
+      FormIdNames.ENTITY,
+      FormIdNames.CURRENCY_CODE,
       FormIdNames.DIRECTION,
       FormIdNames.LEGACY_ACCOUNT_ID,
       FormIdNames.NEXT_GEN_ACCOUNT_ID,
@@ -171,11 +171,11 @@ public class Account {
 
   /** Builds one row filled with an Account's data for the Sheet. */
   public List<String> getAccountSheetsRow(String vendorID) {
-    String[] accountData = { 
-      getAccountID(), 
-      vendorID, 
-      getEntity(), 
-      getCurrency(), 
+    String[] accountData = {
+      getAccountID(),
+      vendorID,
+      getEntity(),
+      getCurrency(),
       getDirection(),
       getLegacyAccountID(),
       Integer.toString(getNextGenAccountID()),
@@ -193,19 +193,27 @@ public class Account {
       "\"currency_code\":\"%s\",\"direction\":\"%s\",\"entity\":\"%s\"}," +
       "\"settlement_config\":{\"matching_mode\":\"%s\"},\"account_id\":\"%s\"," +
       "\"aggregation_mode\":\"%s\"}", getLegacyAccountID(), getNextGenAccountID(),
-      getCurrency(), getDirection(), getEntity(), getMatchingMode(), 
+      getCurrency(), getDirection(), getEntity(), getMatchingMode(),
       getAccountID(), getAggregationMode());
   }
 
   /**
+   * Update existing account information, preventing changes to legacyAccountId
+   * and nextGenAccountId
    * @param request contains form data to edit existing account
+   * @throws IllegalArgumentException thrown when edits are made to protected members
    */
-  public void updateExistingAccount(HttpServletRequest request) {
+  public void updateExistingAccount(HttpServletRequest request)
+          throws IllegalArgumentException {
+    if (!this.legacyAccountID.equals(
+            request.getParameter(FormIdNames.LEGACY_ACCOUNT_ID)) ||
+            this.nextGenAccountID != Integer.parseInt(
+                  request.getParameter(FormIdNames.NEXT_GEN_ACCOUNT_ID))) {
+
+      throw new IllegalArgumentException();
+    }
     this.vendorID = request.getParameter(FormIdNames.VENDOR_ID);
     this.accountID = request.getParameter(FormIdNames.ACCOUNT_ID);
-    this.legacyAccountID = request.getParameter(FormIdNames.LEGACY_ACCOUNT_ID);
-    this.nextGenAccountID = Integer.parseInt(
-            request.getParameter(FormIdNames.NEXT_GEN_ACCOUNT_ID));
     this.currency = request.getParameter(FormIdNames.CURRENCY_CODE);
     this.direction = request.getParameter(FormIdNames.DIRECTION);
     this.entity = request.getParameter(FormIdNames.ENTITY);

--- a/src/main/java/data/JsonConverter.java
+++ b/src/main/java/data/JsonConverter.java
@@ -48,7 +48,6 @@ public class JsonConverter {
     } else {
       String jsonConfig = vendor.buildJsonConfig();
       File config = writeFile(vendor.getVendorID(), jsonConfig);
-      System.out.println("writing file");
       return true;
     }
   }
@@ -147,12 +146,9 @@ public class JsonConverter {
     try {
       String config = getConfig(vendorID);
       Vendor vendor = new Vendor(config, vendorID);
-      ArrayList<Account> accounts = vendor.getAccounts();
       ArrayList<String> accountIds = new ArrayList<String>();
+      vendor.getAccounts().forEach(account -> accountIds.add(account.getAccountID()));
 
-      for (Account account : accounts) {
-        accountIds.add(account.getAccountID());
-      }
       return accountIds;
     } catch (IOException e) {
       throw new IOException("Failed to parse JSON configuration");
@@ -160,12 +156,9 @@ public class JsonConverter {
   }
 
   private ArrayList<String> getAccountIDs(Vendor vendor) {
-    ArrayList<Account> accounts = vendor.getAccounts();
     ArrayList<String> accountIds = new ArrayList<String>();
+    vendor.getAccounts().forEach(account -> accountIds.add(account.getAccountID()));
 
-    for (Account account : accounts) {
-      accountIds.add(account.getAccountID());
-    }
     return accountIds;
   }
 

--- a/src/main/java/data/JsonConverter.java
+++ b/src/main/java/data/JsonConverter.java
@@ -48,6 +48,7 @@ public class JsonConverter {
     } else {
       String jsonConfig = vendor.buildJsonConfig();
       File config = writeFile(vendor.getVendorID(), jsonConfig);
+      System.out.println("writing file");
       return true;
     }
   }
@@ -134,6 +135,10 @@ public class JsonConverter {
     return getVendorIDs().contains(vendorID);
   }
 
+  public boolean accountExists(Vendor vendor, String accountId) {
+    return getAccountIDs(vendor).contains(accountId);
+  }
+
   /**
    * Returns an ArrayList of account ID strings.
    * If none exist for the vendor, an empty ArrayList is returned
@@ -152,6 +157,16 @@ public class JsonConverter {
     } catch (IOException e) {
       throw new IOException("Failed to parse JSON configuration");
     }
+  }
+
+  private ArrayList<String> getAccountIDs(Vendor vendor) {
+    ArrayList<Account> accounts = vendor.getAccounts();
+    ArrayList<String> accountIds = new ArrayList<String>();
+
+    for (Account account : accounts) {
+      accountIds.add(account.getAccountID());
+    }
+    return accountIds;
   }
 
   /** Delete the file that is associated with the desired vendorID. */

--- a/src/main/java/data/Vendor.java
+++ b/src/main/java/data/Vendor.java
@@ -144,6 +144,7 @@ public class Vendor {
   public void editVendorAccount(HttpServletRequest request) {
     String accountId = request.getParameter(FormIdNames.ACCOUNT_ID);
     Account account = getAccountById(accountId);
+    account.update(request);
   }
 
   public void addNewAccount(HttpServletRequest request) {

--- a/src/main/java/data/Vendor.java
+++ b/src/main/java/data/Vendor.java
@@ -101,8 +101,8 @@ public class Vendor {
         return account;
       }
     }
-    // Throw IllegalArgumentException if the account cannot be found in the list.
-    throw new IllegalArgumentException();
+    // returns null when account isn't found in the list.
+    return null;
   }
 
   public static List<String> getVendorSheetHeader() {
@@ -141,12 +141,24 @@ public class Vendor {
     return config;
   }
 
+  /**
+   * Updates the Account specified in the HttpServletRequest.
+   * @param request a request containing form data to edit an existing account
+   */
   public void editVendorAccount(HttpServletRequest request) {
     String accountId = request.getParameter(FormIdNames.ACCOUNT_ID);
     Account account = getAccountById(accountId);
+
+    // Checked previously to see if the account exists, but this confirms
+    // that assumption.
+    assert account != null;
     account.update(request);
   }
 
+  /**
+   * Adds a new Account to the callee.
+   * @param request a request containing form data to create a new account.
+   */
   public void addNewAccount(HttpServletRequest request) {
     Account account = new Account(request);
     addAccount(account);

--- a/src/main/java/data/Vendor.java
+++ b/src/main/java/data/Vendor.java
@@ -46,8 +46,6 @@ public class Vendor {
     this.legacyVendorID = request.getParameter(FormIdNames.LEGACY_CUSTOMER_ID);
     this.nextGenVendorID = Integer.parseInt(request.getParameter(
             FormIdNames.NEXT_GEN_CUSTOMER_ID));
-
-    // TODO: add method to parse variable number of accounts?
     Account newAccount = new Account(request);
     accountList = new ArrayList<>();
     accountList.add(newAccount);
@@ -132,4 +130,8 @@ public class Vendor {
     config += "]}";
     return config;
   }
+//
+//  public Vendor update(Vendor other) {
+//    return;
+//  }
 }

--- a/src/main/java/data/Vendor.java
+++ b/src/main/java/data/Vendor.java
@@ -152,7 +152,7 @@ public class Vendor {
     // Checked previously to see if the account exists, but this confirms
     // that assumption.
     assert account != null;
-    account.update(request);
+    account.updateExistingAccount(request);
   }
 
   /**

--- a/src/main/java/data/Vendor.java
+++ b/src/main/java/data/Vendor.java
@@ -95,6 +95,16 @@ public class Vendor {
     return accountList;
   }
 
+  public Account getAccountById(String accountId) {
+    for (Account account : accountList) {
+      if (account.getAccountID().equals(accountId)) {
+        return account;
+      }
+    }
+    // Throw IllegalArgumentException if the account cannot be found in the list.
+    throw new IllegalArgumentException();
+  }
+
   public static List<String> getVendorSheetHeader() {
     String[] accountData = {  
       FormIdNames.VENDOR_ID, 
@@ -130,8 +140,13 @@ public class Vendor {
     config += "]}";
     return config;
   }
-//
-//  public Vendor update(Vendor other) {
-//    return;
-//  }
+
+  public void editVendorAccount(HttpServletRequest request) {
+    String accountId = request.getParameter(FormIdNames.ACCOUNT_ID);
+    Account account = getAccountById(accountId);
+  }
+
+  public void addNewAccount(HttpServletRequest request) {
+
+  }
 }

--- a/src/main/java/data/Vendor.java
+++ b/src/main/java/data/Vendor.java
@@ -148,6 +148,7 @@ public class Vendor {
   }
 
   public void addNewAccount(HttpServletRequest request) {
-
+    Account account = new Account(request);
+    addAccount(account);
   }
 }

--- a/src/main/java/data/Vendor.java
+++ b/src/main/java/data/Vendor.java
@@ -95,13 +95,16 @@ public class Vendor {
     return accountList;
   }
 
+  /**
+   * Grabs the specified account from account ID. If not found, the method
+   * returns null.
+   */
   public Account getAccountById(String accountId) {
     for (Account account : accountList) {
       if (account.getAccountID().equals(accountId)) {
         return account;
       }
     }
-    // returns null when account isn't found in the list.
     return null;
   }
 
@@ -145,11 +148,9 @@ public class Vendor {
    * Updates the Account specified in the HttpServletRequest.
    * @param request a request containing form data to edit an existing account
    */
-  public void editVendorAccount(HttpServletRequest request) {
+  public void editVendorAccount(HttpServletRequest request) throws IllegalArgumentException {
     String accountId = request.getParameter(FormIdNames.ACCOUNT_ID);
-    Account account = getAccountById(accountId);
-
-    account.updateExistingAccount(request);
+    getAccountById(accountId).updateExistingAccount(request);
   }
 
   /**

--- a/src/main/java/data/Vendor.java
+++ b/src/main/java/data/Vendor.java
@@ -149,9 +149,6 @@ public class Vendor {
     String accountId = request.getParameter(FormIdNames.ACCOUNT_ID);
     Account account = getAccountById(accountId);
 
-    // Checked previously to see if the account exists, but this confirms
-    // that assumption.
-    assert account != null;
     account.updateExistingAccount(request);
   }
 

--- a/src/main/java/servlets/BillingConfig.java
+++ b/src/main/java/servlets/BillingConfig.java
@@ -57,14 +57,19 @@ public class BillingConfig extends HttpServlet {
   public void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
     response.setContentType(CONTENT_TYPE_APPLICATION_JSON);
     try {
-      Vendor newVendor = new Vendor(request);
       JsonConverter jsonConverter = new JsonConverter();
-      if (jsonConverter.updateFile(newVendor)) {
+      String vendorID = request.getParameter(FormIdNames.VENDOR_ID);
+      assert vendorID != null && !vendorID.equals("null");
+
+      Vendor oldConfig = new Vendor(jsonConverter.getConfig(vendorID), vendorID);
+      Vendor newConfig = new Vendor(request);
+
+      if (jsonConverter.updateFile(oldConfig)) {
         // Update Google sheets following update file.
         updateSheets(request);
 
         // Redirect only when the operation succeeded.
-        response.getWriter().println(newVendor.getVendorID());
+        response.getWriter().println(oldConfig.getVendorID());
         response.sendRedirect(REDIRECT_READFILE);
       } else {
         response.sendError(400, "This configuration does not exist.");

--- a/src/main/java/servlets/BillingConfig.java
+++ b/src/main/java/servlets/BillingConfig.java
@@ -63,7 +63,6 @@ public class BillingConfig extends HttpServlet {
       JsonConverter jsonConverter = new JsonConverter();
       String vendorId = request.getParameter(FormIdNames.VENDOR_ID);
       String accountId = request.getParameter(FormIdNames.ACCOUNT_ID);
-
       // Construct vendor object from existing JSON to make changes directly
       Vendor vendor = new Vendor(jsonConverter.getConfig(vendorId), vendorId);
 

--- a/src/main/java/servlets/BillingConfig.java
+++ b/src/main/java/servlets/BillingConfig.java
@@ -102,6 +102,8 @@ public class BillingConfig extends HttpServlet {
               "the Google Sheets API.");
     } catch(IllegalStateException | NullPointerException e) {
       response.sendError(400, "Your OAuth token has expired. Visit /OAuth to refresh");
+    } catch(IllegalArgumentException e) {
+      response.sendError(400, "You cannot edit protected fields");
     }
   }
 }

--- a/src/main/java/servlets/BillingConfig.java
+++ b/src/main/java/servlets/BillingConfig.java
@@ -64,7 +64,7 @@ public class BillingConfig extends HttpServlet {
       String vendorId = request.getParameter(FormIdNames.VENDOR_ID);
       String accountId = request.getParameter(FormIdNames.ACCOUNT_ID);
 
-      // Construct vendor object to make changes directly
+      // Construct vendor object from existing JSON to make changes directly
       Vendor vendor = new Vendor(jsonConverter.getConfig(vendorId), vendorId);
 
       if (jsonConverter.accountExists(vendor, accountId)) {
@@ -72,6 +72,7 @@ public class BillingConfig extends HttpServlet {
         vendor.editVendorAccount(request);
       } else {
         // Create a new account under an existing vendor.
+        vendor.addNewAccount(request);
       }
 
       if (jsonConverter.updateFile(vendor)) {

--- a/src/main/java/servlets/BillingConfig.java
+++ b/src/main/java/servlets/BillingConfig.java
@@ -35,6 +35,11 @@ public class BillingConfig extends HttpServlet {
   private Vendor vendor;
   private Account account;
 
+  /**
+   * Read data endpoint.
+   * @param request form that contains valid vendor and account IDs
+   * @param response returns a configuration in JSON format
+   */
   @Override
   public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException{
     String vendorID = request.getParameter(FormIdNames.VENDOR_ID);
@@ -54,7 +59,13 @@ public class BillingConfig extends HttpServlet {
   }
 
   /**
-   * Edit endpoint.
+   * Edit/update endpoint.
+   * Accepts requests that update existing accounts that belong to an existing
+   * vendor or requests that create new accounts under an existing vendor.
+   * @param request  form data
+   * @param response if the operation succeeds, the vendorId is printed to
+   *                 response object. If the operation fails, a 400 error
+   *                 message is sent.
    */
   @Override
   public void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {

--- a/src/main/java/util/JsonKeys.java
+++ b/src/main/java/util/JsonKeys.java
@@ -7,7 +7,6 @@ public final class JsonKeys {
   public static final String SETTLEMENT_ATTRIBUTES_OBJ =
           "settlement_attributes";
   public static final String LEGACY_CUSTOMER_ID_KEY = "legacy_customer_id";
-  public static final String NEXT_GEN_CUSTOMER_ID_KEY = "next_gen_customer_id";
   public static final String ACCOUNT_ARRAY_KEY = "accounts";
   public static final String CURRENCY_CODE = "currency_code";
   public static final String DIRECTION = "direction";

--- a/src/main/webapp/add-account.html
+++ b/src/main/webapp/add-account.html
@@ -9,20 +9,20 @@
   </head>
   <body onload="javascript:populateCustomerList()">
     <div class="drop_menu">
-			<button class="menu_button">Page Menu</button>
-			<div class="dropdown_content">
-				<a href="readfile.html">Read Configuration</a>
+      <button class="menu_button">Page Menu</button>
+      <div class="dropdown_content">
+        <a href="readfile.html">Read Configuration</a>
         <a href="createfile.html">Create Configuration</a>        
         <a href="editfile.html">Edit Configuration</a>
         <a href="deletefile.html">Delete Configuration</a>
-		  </div>
+      </div>
     </div>
     <h1>Billing Configuration Sync Tool</h1></br>
     <h2>Add Account</h2>
     <div id="edit-account">
       <form id="config-search" onsubmit="buildEditForm(); return false;">
-        <label for="customer-id">Customer ID:</label>
-        <select id="customer-ids" onchange="javascript:populateAccountList()">
+        <label for="customer-ids">Customer ID:</label>
+        <select id="customer-ids" onchange="populateAccountList()">
         </select><br>
         <label for="account-id">Account ID:</label>
         <input type="text" id="account-ids" name="legacy-customer-id"><br><br><br>
@@ -53,7 +53,7 @@
         <input type="text" id="matching-mode" name="matching-mode"><br>
         <p>ACCOUNT</p>
         <label for="account-id">Product Account Key/Account ID:</label>
-        <input type="text" id="account-ids" name="account-id"><br>
+        <input type="text" id="account-id" name="account-id"><br>
         <label for="aggregation-mode">Aggregation Mode:</label>
         <input type="text" id="aggregation-mode" name="aggregation-mode"><br><br>
         <input type="submit"><br><br>

--- a/src/main/webapp/scripts/appscript.js
+++ b/src/main/webapp/scripts/appscript.js
@@ -93,7 +93,7 @@ function buildQueryString() {
 }
 
 /**
- * Validates the fields in teh edit form input and returns true if all fields have a valid format.
+ * Validates the fields in the edit form input and returns true iff all fields have a valid format.
  */
 function validateEditFormInput() {
   const form = document.getElementById('edit-config-form');

--- a/src/test/java/AccountTest.java
+++ b/src/test/java/AccountTest.java
@@ -59,7 +59,6 @@ public final class AccountTest {
   public void setUp() {
     account = new Account(ACCOUNT_ID, VENDOR_ID, ENTITY, CURRENCY, DIRECTION,
             LEGACY_ACCOUNT_ID, NEXT_GEN_ACCOUNT_ID, MATCHING_MODE, AGGREGATION_MODE);
-
   }
 
   /** Test that the constructor set the Vendor fields with the correct data. */
@@ -152,9 +151,11 @@ public final class AccountTest {
     assertEquals(expectedResponse, actualResponse);
   }
 
-  /** Confirm that edits made to an account are applied correctly */
+  /** Confirm that edits made to an account are applied correctly. */
   @Test
   public void testUpdateExistingAccount() {
+    // This request is mocked to return the data that would ordinarily be in
+    // the form that is sent to update an existing account.
     HttpServletRequest request = Mockito.mock(HttpServletRequest.class);
     Mockito.when(request.getParameter(FormIdNames.VENDOR_ID))
             .thenReturn(NEW_VENDOR_ID);

--- a/src/test/java/AccountTest.java
+++ b/src/test/java/AccountTest.java
@@ -177,9 +177,11 @@ public final class AccountTest {
 
     account.updateExistingAccount(request);
 
-    Account expectedAccount = new Account(NEW_ACCOUNT_ID, NEW_VENDOR_ID, NEW_ENTITY, NEW_CURRENCY, NEW_DIRECTION,
-            NEW_LEGACY_ACCOUNT_ID, NEW_NEXT_GEN_ACCOUNT_ID, NEW_MATCHING_MODE, NEW_AGGREGATION_MODE);
+    Account expectedAccount = new Account(NEW_ACCOUNT_ID, NEW_VENDOR_ID,
+            NEW_ENTITY, NEW_CURRENCY, NEW_DIRECTION, NEW_LEGACY_ACCOUNT_ID,
+            NEW_NEXT_GEN_ACCOUNT_ID, NEW_MATCHING_MODE, NEW_AGGREGATION_MODE);
 
-    assertEquals("Failed to update account data", account.buildJsonConfig(), expectedAccount.buildJsonConfig());
+    assertEquals("Failed to update account data", account.buildJsonConfig(),
+            expectedAccount.buildJsonConfig());
   }
 }

--- a/src/test/java/AccountTest.java
+++ b/src/test/java/AccountTest.java
@@ -15,6 +15,7 @@
 package javatests;
 
 import data.Account;
+import org.mockito.Mockito;
 import util.FormIdNames;
 import org.json.JSONObject;
 import org.junit.Before;
@@ -22,6 +23,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
+import javax.servlet.http.HttpServletRequest;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
@@ -42,11 +44,22 @@ public final class AccountTest {
   private final String MATCHING_MODE = "straight";
   private final String AGGREGATION_MODE = "totalAgg";
 
+  private final String NEW_ACCOUNT_ID = "new_acc_12";
+  private final String NEW_VENDOR_ID = "new_vend-21";
+  private final String NEW_ENTITY = "new_shopper";
+  private final String NEW_CURRENCY = "new_USD";
+  private final String NEW_DIRECTION = "new_disbursement";
+  private final String NEW_LEGACY_ACCOUNT_ID = "new_legAcc_53";
+  private final int NEW_NEXT_GEN_ACCOUNT_ID = 100;
+  private final String NEW_MATCHING_MODE = "new_straight";
+  private final String NEW_AGGREGATION_MODE = "new_totalAgg";
+
   /** Create an Account object. */
   @Before
   public void setUp() {
     account = new Account(ACCOUNT_ID, VENDOR_ID, ENTITY, CURRENCY, DIRECTION,
             LEGACY_ACCOUNT_ID, NEXT_GEN_ACCOUNT_ID, MATCHING_MODE, AGGREGATION_MODE);
+
   }
 
   /** Test that the constructor set the Vendor fields with the correct data. */
@@ -137,5 +150,36 @@ public final class AccountTest {
     List<String> actualResponse = account.getAccountSheetsRow(VENDOR_ID);
 
     assertEquals(expectedResponse, actualResponse);
+  }
+
+  /** Confirm that edits made to an account are applied correctly */
+  @Test
+  public void testUpdateExistingAccount() {
+    HttpServletRequest request = Mockito.mock(HttpServletRequest.class);
+    Mockito.when(request.getParameter(FormIdNames.VENDOR_ID))
+            .thenReturn(NEW_VENDOR_ID);
+    Mockito.when(request.getParameter(FormIdNames.ACCOUNT_ID))
+            .thenReturn(NEW_ACCOUNT_ID);
+    Mockito.when(request.getParameter(FormIdNames.LEGACY_ACCOUNT_ID))
+            .thenReturn(NEW_LEGACY_ACCOUNT_ID);
+    Mockito.when(request.getParameter(FormIdNames.NEXT_GEN_ACCOUNT_ID))
+            .thenReturn(String.valueOf(NEW_NEXT_GEN_ACCOUNT_ID));
+    Mockito.when(request.getParameter(FormIdNames.CURRENCY_CODE))
+            .thenReturn(NEW_CURRENCY);
+    Mockito.when(request.getParameter(FormIdNames.DIRECTION))
+            .thenReturn(NEW_DIRECTION);
+    Mockito.when(request.getParameter(FormIdNames.ENTITY))
+            .thenReturn(NEW_ENTITY);
+    Mockito.when(request.getParameter(FormIdNames.MATCHING_MODE))
+            .thenReturn(NEW_MATCHING_MODE);
+    Mockito.when(request.getParameter(FormIdNames.AGGREGATION_MODE))
+            .thenReturn(NEW_AGGREGATION_MODE);
+
+    account.updateExistingAccount(request);
+
+    Account expectedAccount = new Account(NEW_ACCOUNT_ID, NEW_VENDOR_ID, NEW_ENTITY, NEW_CURRENCY, NEW_DIRECTION,
+            NEW_LEGACY_ACCOUNT_ID, NEW_NEXT_GEN_ACCOUNT_ID, NEW_MATCHING_MODE, NEW_AGGREGATION_MODE);
+
+    assertEquals("Failed to update account data", account.buildJsonConfig(), expectedAccount.buildJsonConfig());
   }
 }

--- a/src/test/java/AccountTest.java
+++ b/src/test/java/AccountTest.java
@@ -162,9 +162,9 @@ public final class AccountTest {
     Mockito.when(request.getParameter(FormIdNames.ACCOUNT_ID))
             .thenReturn(NEW_ACCOUNT_ID);
     Mockito.when(request.getParameter(FormIdNames.LEGACY_ACCOUNT_ID))
-            .thenReturn(NEW_LEGACY_ACCOUNT_ID);
+            .thenReturn(LEGACY_ACCOUNT_ID);
     Mockito.when(request.getParameter(FormIdNames.NEXT_GEN_ACCOUNT_ID))
-            .thenReturn(String.valueOf(NEW_NEXT_GEN_ACCOUNT_ID));
+            .thenReturn(String.valueOf(NEXT_GEN_ACCOUNT_ID));
     Mockito.when(request.getParameter(FormIdNames.CURRENCY_CODE))
             .thenReturn(NEW_CURRENCY);
     Mockito.when(request.getParameter(FormIdNames.DIRECTION))
@@ -179,8 +179,8 @@ public final class AccountTest {
     account.updateExistingAccount(request);
 
     Account expectedAccount = new Account(NEW_ACCOUNT_ID, NEW_VENDOR_ID,
-            NEW_ENTITY, NEW_CURRENCY, NEW_DIRECTION, NEW_LEGACY_ACCOUNT_ID,
-            NEW_NEXT_GEN_ACCOUNT_ID, NEW_MATCHING_MODE, NEW_AGGREGATION_MODE);
+            NEW_ENTITY, NEW_CURRENCY, NEW_DIRECTION, LEGACY_ACCOUNT_ID,
+            NEXT_GEN_ACCOUNT_ID, NEW_MATCHING_MODE, NEW_AGGREGATION_MODE);
 
     assertEquals("Failed to update account data", account.buildJsonConfig(),
             expectedAccount.buildJsonConfig());

--- a/src/test/java/JsonConverterTest.java
+++ b/src/test/java/JsonConverterTest.java
@@ -87,7 +87,6 @@ public final class JsonConverterTest {
   public void testGetConfigMethod() {
     String expectedResponse = "{\"legacy_customer_id\":\"legVend_27\",\"next_gen_customer_id\":17,\"accounts\":[]}";
     String actualResponse = converter.getConfig(VENDOR_ID);
-
     assertEquals(removeWhitespace(expectedResponse), removeWhitespace(actualResponse));
   }
 
@@ -182,5 +181,13 @@ public final class JsonConverterTest {
     Collections.sort(actualVendorIDs);
 
     assertTrue(expectedVendorIDs.equals(actualVendorIDs));
+  }
+
+  @Test
+  public void testAccountExists() {
+    vendor.addAccount(account);
+    boolean actualResponse = converter.accountExists(vendor, ACCOUNT_ID);
+    boolean expectedResponse = true;
+    assertEquals(actualResponse, expectedResponse);
   }
 }

--- a/src/test/java/VendorTest.java
+++ b/src/test/java/VendorTest.java
@@ -129,7 +129,7 @@ public final class VendorTest {
   @Test
   public void testGetAccountById() {
     vendor.addAccount(account);
-    // Accounts should have the same memory address, so direct comparison is OK
+    // Accounts should have the same memory address, so direct comparison is OK.
     assertEquals(account, vendor.getAccountById(ACCOUNT_ID));
   }
 }

--- a/src/test/java/VendorTest.java
+++ b/src/test/java/VendorTest.java
@@ -112,7 +112,7 @@ public final class VendorTest {
     assertEquals(expectedResponse, actualResponse);
   }
 
- /** Test that getVendorSheetsRow returns a List representing its data. */
+  /** Test that getVendorSheetsRow returns a List representing its data. */
   @Test
   public void testGetAccountSheetsRowMethod() {
     String[] expectedArray = {
@@ -123,5 +123,13 @@ public final class VendorTest {
     List<String> actualResponse = vendor.getVendorSheetsRow();
 
     assertEquals(expectedResponse, actualResponse);
+  }
+
+  /** Ensure grabbing accountById doesn't return null. */
+  @Test
+  public void testGetAccountById() {
+    vendor.addAccount(account);
+    // Accounts should have the same memory address, so direct comparison is OK
+    assertEquals(account, vendor.getAccountById(ACCOUNT_ID));
   }
 }


### PR DESCRIPTION
### Description
This PR catches up the backend with #65. It changes edit functionality to only edit the specified account, and allows a user to create and edit a new account belonging to a vendor. This endpoint should not be functional if the user's accountID or vendorID do not exist in the system: those changes should go to the new create endpoint. 

### To do:
- [ ] Prevent form submission if vendor or account ID do not exist
