### PR TITLE
Add support for different GET requests on BillingServlet

### DIFF
--- a/src/main/java/data/JsonConverter.java
+++ b/src/main/java/data/JsonConverter.java
@@ -91,11 +91,14 @@ public class JsonConverter {
   }
 
   public String getAccountConfig(String vendorId, String accountId)
-          throws IllegalArgumentException, FileNotFoundException, IOException {
+          throws IllegalArgumentException, IOException {
 
     String config = getConfigText(vendorId);
     Vendor vendor = new Vendor(config, vendorId);
     Account account = vendor.getAccountById(accountId);
+    if (account == null) {
+      throw new IllegalArgumentException();
+    }
     return account.buildJsonConfig();
   }
 

--- a/src/main/java/data/JsonConverter.java
+++ b/src/main/java/data/JsonConverter.java
@@ -74,15 +74,14 @@ public class JsonConverter {
 
   /**
    * Retrieve and return the contents of the desired configuration.
-   * @throws FileNotFoundException thrown when configuration is not found
+   * @throws FileNotFoundException thrown when configuration is not found.
    */
   public String getConfigText(String vendorID) throws FileNotFoundException {
     String configContents = "";
     // Retrieve the file with the corresponding vendorID.
     File config = new File(basePath + vendorID);
 
-    Scanner input;
-    input = new Scanner(config);
+    Scanner input = new Scanner(config);
 
     while (input.hasNextLine()) {
       configContents += input.nextLine();

--- a/src/main/java/data/JsonConverter.java
+++ b/src/main/java/data/JsonConverter.java
@@ -95,8 +95,8 @@ public class JsonConverter {
 
     String config = getConfigText(vendorId);
     Vendor vendor = new Vendor(config, vendorId);
-    // get account by ID
-    return "dummy";
+    Account account = vendor.getAccountById(accountId);
+    return account.buildJsonConfig();
   }
 
   /**

--- a/src/main/java/data/JsonConverter.java
+++ b/src/main/java/data/JsonConverter.java
@@ -74,24 +74,29 @@ public class JsonConverter {
 
   /**
    * Retrieve and return the contents of the desired configuration.
+   * @throws FileNotFoundException thrown when configuration is not found
    */
-  public String getConfig(String vendorID) {
+  public String getConfigText(String vendorID) throws FileNotFoundException {
     String configContents = "";
-
     // Retrieve the file with the corresponding vendorID.
     File config = new File(basePath + vendorID);
 
     Scanner input;
-    try {
-      input = new Scanner(config);
-    } catch(FileNotFoundException e) {
-      return null;
-    }
+    input = new Scanner(config);
 
     while (input.hasNextLine()) {
       configContents += input.nextLine();
     }
     return configContents;
+  }
+
+  public String getAccountConfig(String vendorId, String accountId)
+          throws IllegalArgumentException, FileNotFoundException, IOException {
+
+    String config = getConfigText(vendorId);
+    Vendor vendor = new Vendor(config, vendorId);
+    // get account by ID
+
   }
 
   /**
@@ -140,7 +145,7 @@ public class JsonConverter {
    */
   private ArrayList<String> getAccountIDs(String vendorID) throws IOException {
     try {
-      String config = getConfig(vendorID);
+      String config = getConfigText(vendorID);
       Vendor vendor = new Vendor(config, vendorID);
       ArrayList<Account> accounts = vendor.getAccounts();
       ArrayList<String> accountIds = new ArrayList<String>();

--- a/src/main/java/data/JsonConverter.java
+++ b/src/main/java/data/JsonConverter.java
@@ -96,7 +96,8 @@ public class JsonConverter {
     Vendor vendor = new Vendor(config, vendorId);
     Account account = vendor.getAccountById(accountId);
     if (account == null) {
-      throw new IllegalArgumentException();
+      // Throw error if account is not found.
+      throw new IllegalArgumentException("Account with ID " + accountId + " not found.");
     }
     return account.buildJsonConfig();
   }

--- a/src/main/java/data/Vendor.java
+++ b/src/main/java/data/Vendor.java
@@ -52,7 +52,7 @@ public class Vendor {
   }
 
   /** Construct a Vendor object from JSON string. */
-  public Vendor(String json, String vendorID) throws IOException{
+  public Vendor(String json, String vendorID) throws IOException {
     JSONObject vendorJson = new JSONObject(json);
     this.vendorID = vendorID;
     this.legacyVendorID = vendorJson.getString(JsonKeys.LEGACY_CUSTOMER_ID_KEY);

--- a/src/main/java/servlets/BillingConfig.java
+++ b/src/main/java/servlets/BillingConfig.java
@@ -46,13 +46,12 @@ public class BillingConfig extends HttpServlet {
     try {
       JsonConverter json = new JsonConverter();
       String configText;
-      if (accountID == null || !accountID.equals("null")) {
+      if (accountID == null || accountID.equals("null")) {
         // If an AccountID is not set, print the entire configuration.
         configText = json.getConfigText(vendorID);
       } else {
         configText = json.getAccountConfig(vendorID, accountID);
       }
-      response.getWriter().println(configText);
     } catch (FileNotFoundException e) {
       response.sendError(400, "Error finding " + vendorID + "'s configuration");
     }

--- a/src/main/java/servlets/BillingConfig.java
+++ b/src/main/java/servlets/BillingConfig.java
@@ -30,10 +30,7 @@ import static servlets.VendorServlet.updateSheets;
 @WebServlet("/BillingConfig")
 public class BillingConfig extends HttpServlet {
   private static final String CONTENT_TYPE_APPLICATION_JSON = "application/json;";
-  private static final String REDIRECT_READFILE = "/index.html";
-
-  private Vendor vendor;
-  private Account account;
+  private static final String REDIRECT_INDEX = "/index.html";
 
   @Override
   public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException{
@@ -65,7 +62,7 @@ public class BillingConfig extends HttpServlet {
 
         // Redirect only when the operation succeeded.
         response.getWriter().println(newVendor.getVendorID());
-        response.sendRedirect(REDIRECT_READFILE);
+        response.sendRedirect(REDIRECT_INDEX);
       } else {
         response.sendError(400, "This configuration does not exist.");
       }

--- a/src/main/java/servlets/BillingConfig.java
+++ b/src/main/java/servlets/BillingConfig.java
@@ -42,6 +42,7 @@ public class BillingConfig extends HttpServlet {
   public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
     String vendorID = request.getParameter(FormIdNames.VENDOR_ID);
     String accountID = request.getParameter(FormIdNames.ACCOUNT_ID);
+    // When getEntireConfig==true, return the entire configuration string.
     boolean getEntireConfig = Boolean.parseBoolean(request.getParameter(
             FormIdNames.ENTIRE_CONFIG));
     response.setContentType(CONTENT_TYPE_APPLICATION_JSON);
@@ -50,10 +51,10 @@ public class BillingConfig extends HttpServlet {
       JsonConverter json = new JsonConverter();
       String configText;
       if (getEntireConfig) {
-        // The edit form endpoint asks for the entire configuration text
+        // The edit form endpoint asks for the entire configuration text.
         configText = json.getConfigText(vendorID);
       } else {
-        // Read data endpoint asks for configuration text of one account
+        // Read data endpoint asks for configuration text of one account.
         configText = json.getAccountConfig(vendorID, accountID);
       }
       response.getWriter().println(configText);

--- a/src/main/java/servlets/BillingConfig.java
+++ b/src/main/java/servlets/BillingConfig.java
@@ -31,6 +31,7 @@ import static servlets.VendorServlet.updateSheets;
 public class BillingConfig extends HttpServlet {
   private static final String CONTENT_TYPE_APPLICATION_JSON = "application/json;";
   private static final String REDIRECT_INDEX = "/index.html";
+  private static final String EDIT_FORM_DESTINATION = "editForm";
 
   /**
    * Read data endpoint.
@@ -41,15 +42,17 @@ public class BillingConfig extends HttpServlet {
   public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
     String vendorID = request.getParameter(FormIdNames.VENDOR_ID);
     String accountID = request.getParameter(FormIdNames.ACCOUNT_ID);
+    String destination = request.getParameter(FormIdNames.DESTINATION);
     response.setContentType(CONTENT_TYPE_APPLICATION_JSON);
 
     try {
       JsonConverter json = new JsonConverter();
       String configText;
-      if (accountID == null || accountID.equals("null")) {
-        // If an AccountID is not set, print the entire configuration.
+      if (destination != null && destination.equals(EDIT_FORM_DESTINATION)) {
+        // The edit form endpoint asks for the entire configuration text
         configText = json.getConfigText(vendorID);
       } else {
+        // Read data endpoint asks for configuration text of one account
         configText = json.getAccountConfig(vendorID, accountID);
       }
       response.getWriter().println(configText);

--- a/src/main/java/servlets/BillingConfig.java
+++ b/src/main/java/servlets/BillingConfig.java
@@ -52,6 +52,7 @@ public class BillingConfig extends HttpServlet {
       } else {
         configText = json.getAccountConfig(vendorID, accountID);
       }
+      response.getWriter().println(configText);
     } catch (FileNotFoundException e) {
       response.sendError(400, "Error finding " + vendorID + "'s configuration");
     }

--- a/src/main/java/servlets/BillingConfig.java
+++ b/src/main/java/servlets/BillingConfig.java
@@ -15,40 +15,41 @@ package servlets;
 
 import data.JsonConverter;
 import data.Vendor;
+import util.FormIdNames;
+import static servlets.VendorServlet.updateSheets;
 
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.security.GeneralSecurityException;
 import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import util.FormIdNames;
 
-import static servlets.VendorServlet.updateSheets;
 
 @WebServlet("/BillingConfig")
 public class BillingConfig extends HttpServlet {
   private static final String CONTENT_TYPE_APPLICATION_JSON = "application/json;";
   private static final String REDIRECT_INDEX = "/index.html";
-  private static final String EDIT_FORM_DESTINATION = "editForm";
 
   /**
-   * Read data endpoint.
+   * Read data endpoint for both the edit and read pages.
+   *
    * @param request form that contains valid vendor and account IDs
+   *                required fields: String vendorID & boolean entireConfig
    * @param response returns a configuration in JSON format
    */
   @Override
   public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
     String vendorID = request.getParameter(FormIdNames.VENDOR_ID);
     String accountID = request.getParameter(FormIdNames.ACCOUNT_ID);
-    String destination = request.getParameter(FormIdNames.DESTINATION);
+    boolean getEntireConfig = Boolean.parseBoolean(request.getParameter(
+            FormIdNames.ENTIRE_CONFIG));
     response.setContentType(CONTENT_TYPE_APPLICATION_JSON);
 
     try {
       JsonConverter json = new JsonConverter();
       String configText;
-      if (destination != null && destination.equals(EDIT_FORM_DESTINATION)) {
+      if (getEntireConfig) {
         // The edit form endpoint asks for the entire configuration text
         configText = json.getConfigText(vendorID);
       } else {

--- a/src/main/java/servlets/BillingConfig.java
+++ b/src/main/java/servlets/BillingConfig.java
@@ -42,12 +42,14 @@ public class BillingConfig extends HttpServlet {
   public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
     String vendorID = request.getParameter(FormIdNames.VENDOR_ID);
     String accountID = request.getParameter(FormIdNames.ACCOUNT_ID);
-    // When getEntireConfig==true, return the entire configuration string.
-    boolean getEntireConfig = Boolean.parseBoolean(request.getParameter(
-            FormIdNames.ENTIRE_CONFIG));
+
     response.setContentType(CONTENT_TYPE_APPLICATION_JSON);
 
     try {
+      // When getEntireConfig==true, return the entire configuration string.
+      boolean getEntireConfig = Boolean.parseBoolean(request.getParameter(
+              FormIdNames.ENTIRE_CONFIG));
+
       JsonConverter json = new JsonConverter();
       String configText;
       if (getEntireConfig) {

--- a/src/main/java/servlets/BillingConfig.java
+++ b/src/main/java/servlets/BillingConfig.java
@@ -15,8 +15,8 @@ package servlets;
 
 import data.JsonConverter;
 import data.Vendor;
-import data.Account;
 
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.security.GeneralSecurityException;
 import javax.servlet.annotation.WebServlet;
@@ -33,21 +33,24 @@ public class BillingConfig extends HttpServlet {
   private static final String REDIRECT_INDEX = "/index.html";
 
   @Override
-  public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException{
+  public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
     String vendorID = request.getParameter(FormIdNames.VENDOR_ID);
     String accountID = request.getParameter(FormIdNames.ACCOUNT_ID);
-
-    JsonConverter json = new JsonConverter();
-    String configText = "";
-
-    if (json.getConfig(vendorID) != null) {
-      configText = json.getConfig(vendorID);
-    } else {
-      configText = "Error finding " + vendorID + "'s configuration";
-    }
-
     response.setContentType(CONTENT_TYPE_APPLICATION_JSON);
-    response.getWriter().println(configText);
+
+    try {
+      JsonConverter json = new JsonConverter();
+      System.out.println(accountID);
+      if (accountID == null || !accountID.equals("null")) {
+        // If an AccountID is not set, print the entire configuration.
+        String configText = json.getConfigText(vendorID);
+      } else {
+        String configText = json.getAccountConfig(vendorID, accountID);
+      }
+      response.getWriter().println(configText);
+    } catch (FileNotFoundException e) {
+      response.sendError(400, "Error finding " + vendorID + "'s configuration");
+    }
   }
 
   @Override

--- a/src/main/java/servlets/BillingConfig.java
+++ b/src/main/java/servlets/BillingConfig.java
@@ -53,8 +53,11 @@ public class BillingConfig extends HttpServlet {
         configText = json.getAccountConfig(vendorID, accountID);
       }
       response.getWriter().println(configText);
-    } catch (FileNotFoundException e) {
+    } catch (IOException e) {
       response.sendError(400, "Error finding " + vendorID + "'s configuration");
+    } catch (IllegalArgumentException e) {
+      response.sendError(400, "Failed to find account associated with vendor "
+              + vendorID);
     }
   }
 

--- a/src/main/java/servlets/VendorServlet.java
+++ b/src/main/java/servlets/VendorServlet.java
@@ -15,7 +15,6 @@ package servlets;
 
 import data.JsonConverter;
 import data.Vendor;
-import data.Account;
 import data.SheetsConverter;
 
 import java.util.*;
@@ -108,7 +107,7 @@ public class VendorServlet extends HttpServlet {
     ArrayList<Vendor> vendors = new ArrayList<Vendor>();
 
     for (int i = 0; i < vendorIDs.size(); i++) {
-      String vendorJson = converter.getConfig(vendorIDs.get(i));
+      String vendorJson = converter.getConfigText(vendorIDs.get(i));
       vendors.add(new Vendor(vendorJson, vendorIDs.get(i)));
     }
     return vendors;

--- a/src/main/java/util/FormIdNames.java
+++ b/src/main/java/util/FormIdNames.java
@@ -12,5 +12,5 @@ public final class FormIdNames {
   public static final String ENTITY = "entity";
   public static final String MATCHING_MODE = "matching-mode";
   public static final String AGGREGATION_MODE = "aggregation-mode";
-  public static final String DESTINATION = "destination";
+  public static final String ENTIRE_CONFIG = "entireConfig";
 }

--- a/src/main/java/util/FormIdNames.java
+++ b/src/main/java/util/FormIdNames.java
@@ -12,4 +12,5 @@ public final class FormIdNames {
   public static final String ENTITY = "entity";
   public static final String MATCHING_MODE = "matching-mode";
   public static final String AGGREGATION_MODE = "aggregation-mode";
+  public static final String DESTINATION = "destination";
 }

--- a/src/main/webapp/assets/readfile.css
+++ b/src/main/webapp/assets/readfile.css
@@ -10,5 +10,9 @@
   margin: auto;
   padding: 50px;
   width: 500px;
+  background-color: #efefef
 }
 
+pre {
+  text-align: left;
+}

--- a/src/main/webapp/assets/readfile.css
+++ b/src/main/webapp/assets/readfile.css
@@ -10,7 +10,7 @@
   margin: auto;
   padding: 50px;
   width: 500px;
-  background-color: #efefef
+  background-color: rgb(239, 239, 239);
 }
 
 pre {

--- a/src/main/webapp/edit-account.html
+++ b/src/main/webapp/edit-account.html
@@ -9,26 +9,25 @@
   </head>
   <body onload="javascript:populateCustomerList()">
     <div class="drop_menu">
-			<button class="menu_button">Page Menu</button>
-			<div class="dropdown_content">
-				<a href="readfile.html">Read Configuration</a>
+      <button class="menu_button">Page Menu</button>
+      <div class="dropdown_content">
+        <a href="readfile.html">Read Configuration</a>
         <a href="createfile.html">Create Configuration</a>        
         <a href="editfile.html">Edit Configuration</a>
         <a href="deletefile.html">Delete Configuration</a>
-		  </div>
+      </div>
     </div>
     <h1>Billing Configuration Sync Tool</h1></br>
     <h2>Edit Account</h2>
     <div id="edit-account">
       <form id="config-search" onsubmit="buildEditForm(); return false;">
-        <label for="customer-id">Customer ID:</label>
+        <label for="customer-ids">Customer ID:</label>
         <select id="customer-ids" onchange="javascript:populateAccountList()">
         </select><br>
         <label for="account-id">Account ID:</label>
         <select id="account-ids">
         </select><br><br>
-        <button type="submit" onclick="javascript:populateEditForm()">
-          Edit Account</button><br><br>
+        <button type="submit">Edit Account</button><br><br>
      </form>
     </div>
     <div id="edit-form">

--- a/src/main/webapp/editfile.html
+++ b/src/main/webapp/editfile.html
@@ -8,13 +8,13 @@
   </head>
   <body onload="javascript:populateCustomerList()">
     <div class="drop_menu">
-			<button class="menu_button">Page Menu</button>
-			<div class="dropdown_content">
-				<a href="readfile.html">Read Configuration</a>
+      <button class="menu_button">Page Menu</button>
+      <div class="dropdown_content">
+        <a href="readfile.html">Read Configuration</a>
         <a href="createfile.html">Create Configuration</a>        
         <a href="editfile.html">Edit Configuration</a>
         <a href="deletefile.html">Delete Configuration</a>
-		  </div>
+      </div>
     </div>
     <h1>Billing Configuration Sync Tool</h1></br>
     <h2>Edit Configuration</h2>

--- a/src/main/webapp/readfile.html
+++ b/src/main/webapp/readfile.html
@@ -9,13 +9,13 @@
   </head>
   <body onload="javascript:populateCustomerList()">
     <div class="drop_menu">
-			<button class="menu_button">Page Menu</button>
-			<div class="dropdown_content">
-				<a href="readfile.html">Read Configuration</a>
+      <button class="menu_button">Page Menu</button>
+      <div class="dropdown_content">
+        <a href="readfile.html">Read Configuration</a>
         <a href="createfile.html">Create Configuration</a>        
         <a href="editfile.html">Edit Configuration</a>
         <a href="deletefile.html">Delete Configuration</a>
-		  </div>
+      </div>
     </div>
     <h1>Billing Configuration Sync Tool</h1><br>
     <h2>Read Configuration</h2> 

--- a/src/main/webapp/scripts/appscript.js
+++ b/src/main/webapp/scripts/appscript.js
@@ -80,16 +80,17 @@ function buildEditForm() {
 
 /**
  * Builds a query string specific to the edit form to fetch an entire configuration
- * @return {string}   contains "vendorID" and "destination", where vendorID is the associated ID and
- *                    destination should equal editForm
+ * @return {string}   contains "vendorID" and "entireConfig", where vendorID is the associated ID and
+ *                    entireConfig is a boolean that should be true, returning the entire config text
  */
 function buildQueryStringEditForm() {
   const selectedVendorId = document.getElementById('customer-ids').value;
-  return `/BillingConfig?vendorID=${selectedVendorId}&destination=editForm`;
+  return `/BillingConfig?vendorID=${selectedVendorId}&entireConfig=true`;
 }
 
 /**
  * Builds a generic query string containing vendor and account IDs
+ * entireConfig=false denotes the response should only contain the specified account
  */
 function buildQueryString() {
   const selectedVendorId = document.getElementById('customer-ids').value;
@@ -98,7 +99,7 @@ function buildQueryString() {
   if (selectedAccountId == "") {
     window.alert("A vendor ID and account ID have not been set yet!");
   } else {
-    return `/BillingConfig?vendorID=${selectedVendorId}&accountID=${selectedAccountId}`;
+    return `/BillingConfig?vendorID=${selectedVendorId}&accountID=${selectedAccountId}&entireConfig=false`;
   }
 }
 

--- a/src/main/webapp/scripts/appscript.js
+++ b/src/main/webapp/scripts/appscript.js
@@ -78,11 +78,19 @@ function buildEditForm() {
   showForm();
 }
 
+/**
+ * Builds a query string specific to the edit form to fetch an entire configuration
+ * @return {string}   contains "vendorID" and "destination", where vendorID is the associated ID and
+ *                    destination should equal editForm
+ */
 function buildQueryStringEditForm() {
   const selectedVendorId = document.getElementById('customer-ids').value;
   return `/BillingConfig?vendorID=${selectedVendorId}&destination=editForm`;
 }
 
+/**
+ * Builds a generic query string containing vendor and account IDs
+ */
 function buildQueryString() {
   const selectedVendorId = document.getElementById('customer-ids').value;
   const selectedAccountId = document.getElementById('account-ids').value;

--- a/src/main/webapp/scripts/appscript.js
+++ b/src/main/webapp/scripts/appscript.js
@@ -74,14 +74,20 @@ async function addConfigToPage() {
 function buildEditForm() {
   const editForm = document.getElementById('edit-config-form');
   editForm.action = buildQueryString();
+  populateEditForm();
   showForm();
+}
+
+function buildQueryStringEditForm() {
+  const selectedVendorId = document.getElementById('customer-ids').value;
+  return `/BillingConfig?vendorID=${selectedVendorId}&destination=editForm`;
 }
 
 function buildQueryString() {
   const selectedVendorId = document.getElementById('customer-ids').value;
   const selectedAccountId = document.getElementById('account-ids').value;
   // check for space in accountID.
-  if(selectedAccountId == "") {
+  if (selectedAccountId == "") {
     window.alert("A vendor ID and account ID have not been set yet!");
   } else {
     return `/BillingConfig?vendorID=${selectedVendorId}&accountID=${selectedAccountId}`;
@@ -123,9 +129,8 @@ function validateEditFormInput() {
   }
 }
 
-// TODO @cade: have BillingConfig return one Account, not enitre config.
 async function populateEditForm() {
-  const queryString = buildQueryString();
+  const queryString = buildQueryStringEditForm();
   fetch(queryString).then(response => {
     return response.json();
   }).then(data => {
@@ -147,9 +152,4 @@ async function populateEditForm() {
 // TODO: Method for enums: Check which of the tags has data under it {isLoggedIn:{loginURL},isLoggedOut:{logooutURL}}}
 async function checkLoginStatus() {
   
-}
-
-// TODO: Create config and redirect/populate edit form. 
-async function createConfiguration() {
-
 }

--- a/src/test/java/JsonConverterTest.java
+++ b/src/test/java/JsonConverterTest.java
@@ -84,26 +84,24 @@ public final class JsonConverterTest {
    * The vendorID must match an existing filepath in the filesystem.
    */
   @Test
-  public void testGetConfigMethod() {
-    String expectedResponse = "{\"legacy_customer_id\":\"legVend_27\",\"next_gen_customer_id\":17,\"accounts\":[]}";
-    String actualResponse = converter.getConfig(VENDOR_ID);
+  public void testGetConfigMethod() throws FileNotFoundException {
+    String expectedResponse = "{\"legacy_customer_id\":\"legVend_27\"," +
+            "\"next_gen_customer_id\":17,\"accounts\":[]}";
+    String actualResponse = converter.getConfigText(VENDOR_ID);
 
-    assertEquals(removeWhitespace(expectedResponse), removeWhitespace(actualResponse));
+    assertEquals(removeWhitespace(expectedResponse),
+            removeWhitespace(actualResponse));
   }
 
   /**
-   * Test that getConfig() returns null when faulty vendorID is passed in.
+   * Test that getConfig() throws exception when faulty vendorID is passed in.
    * The vendorID must match an existing filepath in the filesystem.
    */
-  @Test
-  public void testGetConfigMethodWithFakeVendorID() {
+  @Test(expected = FileNotFoundException.class)
+  public void testGetConfigMethodWithFakeVendorID() throws FileNotFoundException {
     String vendorID = "fakeVendorID";
     String expectedResponse = null;
-
-    String actualResponse = converter.getConfig(vendorID);
-
-    assertTrue("getConfig() didn't return null when it should have.",
-            expectedResponse == actualResponse);
+    String actualResponse = converter.getConfigText(vendorID);
   }
 
   /** Test that writeFile() returns a File with the expected content. */


### PR DESCRIPTION
### Description
This PR solves a lot of the problems that existed with the read endpoint of our servlets. Now, the read file page displays only the selected account information, and the populate text feature of the edit form is working again. 

* GET Requests to the BillingConfig servlet need a new flag that signals if the servlet should return an entire configuration or the specified account's configuration. 
* Small changes to refactor the JS remove some redundancy and make the process of building the edit form more explicity
* Adds error handling on BillingConfig's GET endpoint
* Minor updates to formatting
### Issues resolved
- Closes #76 